### PR TITLE
[Issue #98] Added option to use bucket name directly as host

### DIFF
--- a/lib/classes/class-bootstrap.php
+++ b/lib/classes/class-bootstrap.php
@@ -767,7 +767,12 @@ namespace wpCloud\StatelessMedia {
        */
       public function upload_dir( $data ) {
 
-        $data[ 'baseurl' ] = '//storage.googleapis.com/' . ( $this->get( 'sm.bucket' ) );
+        $image_host = 'https://storage.googleapis.com/';
+        if ( ud_get_stateless_media()->get( 'sm.static_host' ) ) {
+          $image_host = 'https://';
+        }
+
+        $data[ 'baseurl' ] = $image_host . ( $this->get( 'sm.bucket' ) );
         $data[ 'url' ] = $data[ 'baseurl' ] . $data[ 'subdir' ];
 
         return $data;

--- a/lib/classes/class-bootstrap.php
+++ b/lib/classes/class-bootstrap.php
@@ -349,8 +349,12 @@ namespace wpCloud\StatelessMedia {
             $baseurl = preg_replace('/https?:\/\//','',$upload_data['baseurl']);
             $root_dir = trim( $this->get( 'sm.root_dir' ) );
             $root_dir = !empty( $root_dir ) ? $root_dir : false;
+            $image_host = 'storage.googleapis.com/';
+            if ( $this->get( 'sm.static_host' )) {
+                $image_host = '';  // bucketname will be host
+            }
             $content = preg_replace( '/(href|src)=(\'|")(https?:\/\/'.str_replace('/', '\/', $baseurl).')\/(.+?)(\.jpg|\.png|\.gif|\.jpeg)(\'|")/i',
-                '$1=$2https://storage.googleapis.com/'.$this->get( 'sm.bucket' ).'/'.($root_dir?$root_dir:'').'$4$5$6', $content);
+                '$1=$2https://'.$image_host.$this->get( 'sm.bucket' ).'/'.($root_dir?$root_dir:'').'$4$5$6', $content);
           }
         }
 

--- a/lib/classes/class-settings.php
+++ b/lib/classes/class-settings.php
@@ -45,6 +45,7 @@ namespace wpCloud\StatelessMedia {
               'bucket' => get_option( 'sm_bucket' ),
               'root_dir' => get_option( 'sm_root_dir' ),
               'key_json' => get_option( 'sm_key_json' ),
+              'static_host' => get_option( 'sm_static_host' ),
               'body_rewrite' => get_option( 'sm_body_rewrite' ),
               'on_fly' => get_option( 'sm_on_fly' ),
               'delete_remote' => get_option( 'sm_delete_remote' ),
@@ -182,6 +183,7 @@ namespace wpCloud\StatelessMedia {
           'bucket' => get_option( 'sm_bucket' ),
           'root_dir' => get_option( 'sm_root_dir' ),
           'key_json' => get_option( 'sm_key_json' ),
+          'static_host' => get_option( 'sm_static_host' ),
           'body_rewrite' => get_option( 'sm_body_rewrite' ),
           'on_fly' => get_option( 'sm_on_fly' ),
           'delete_remote' => get_option( 'sm_delete_remote' ),
@@ -363,6 +365,11 @@ namespace wpCloud\StatelessMedia {
 
         // cache control input
         $inputs[] = '<input id="sm_cache_control" class="regular-text" type="text" name="sm[cache_control]" value="'.$this->get( 'sm.cache_control' ).'" />';
+
+        // use bucketname for static hosting
+        $inputs[] = '<input type="hidden" name="sm[static_host]" value="false" />';
+        $inputs[] = '<label for="sm_static_host"><input id="sm_static_host" type="checkbox" name="sm[static_host]" value="true" '. checked( 'true', $this->get
+( 'sm.static_host' ), false ) .'/>'.__( 'Use bucketname as hostname.', ud_get_stateless_media()->domain ).'</label>';
 
         // body content rewrite
         $inputs[] = '<input type="hidden" name="sm[body_rewrite]" value="false" />';

--- a/lib/classes/class-utility.php
+++ b/lib/classes/class-utility.php
@@ -161,7 +161,11 @@ namespace wpCloud\StatelessMedia {
 
           $file = wp_normalize_path( $metadata[ 'file' ] );
 
-          $bucketLink = apply_filters('wp_stateless_bucket_link', 'https://storage.googleapis.com/' . ud_get_stateless_media()->get( 'sm.bucket' ));
+          $image_host = 'storage.googleapis.com/';
+          if ( ud_get_stateless_media()->get( 'sm.static_host' ) ) {
+            $image_host = '';
+          }
+          $bucketLink = apply_filters('wp_stateless_bucket_link', 'https://'.$image_host.ud_get_stateless_media()->get( 'sm.bucket' ));
 
           $_metadata = array(
             "width" => isset( $metadata[ 'width' ] ) ? $metadata[ 'width' ] : null,


### PR DESCRIPTION
- Added checkbox option under `Advanced` section in Settings > Media.
- When checked, bucket name will be used as direct host of images instead of `storage.googleapis.com/`
- This option is only meant for cases where the bucket is set up for static hosting (e.g. image subdomain as a CNAME record).