### PR TITLE
CDN Only implementation

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,6 @@
+#### 1.9.3
+* Added CDN Only mode
+
 #### 1.9.2
 * Improvements to onboarding process. [wip]
 * Added Featre Flag support for globally enabling/disabling functionality.

--- a/lib/classes/class-bootstrap.php
+++ b/lib/classes/class-bootstrap.php
@@ -4,11 +4,13 @@
  *
  * @since 0.2.0
  */
+
 namespace wpCloud\StatelessMedia {
 
-  if( !class_exists( 'wpCloud\StatelessMedia\Bootstrap' ) ) {
+  if (!class_exists('wpCloud\StatelessMedia\Bootstrap')) {
 
-    final class Bootstrap extends \UsabilityDynamics\WP\Bootstrap_Plugin {
+    final class Bootstrap extends \UsabilityDynamics\WP\Bootstrap_Plugin
+    {
 
       /**
        * Google Storage Client
@@ -40,7 +42,8 @@ namespace wpCloud\StatelessMedia {
       /**
        * Instantaite class.
        */
-      public function init() {
+      public function init()
+      {
 
         /**
          * Copied from wp-property
@@ -53,27 +56,27 @@ namespace wpCloud\StatelessMedia {
          * @since 1.9.1
          */
         load_plugin_textdomain($this->domain, false, dirname(plugin_basename($this->boot_file)) . '/static/languages/');
-        
+
         // Parse feature falgs, set constants.
         $this->parse_feature_flags();
 
         // Invoke REST API
-        add_action( 'rest_api_init', array( $this, 'api_init' ) );
+        add_action('rest_api_init', [$this, 'api_init']);
 
         /**
          * Register SM metaboxes
          */
-        add_action( 'admin_init', array( $this, 'register_metaboxes' ) );
+        add_action('admin_init', [$this, 'register_metaboxes']);
 
         /**
          * Add custom actions to media rows
          */
-        add_filter( 'media_row_actions', array( $this, 'add_custom_row_actions' ), 10, 3 );
+        add_filter('media_row_actions', [$this, 'add_custom_row_actions'], 10, 3);
 
         /**
          * Handle switch blog properly.
          */
-        add_action( 'switch_blog', array( $this, 'on_switch_blog' ), 10, 2 );
+        add_action('switch_blog', [$this, 'on_switch_blog'], 10, 2);
 
         /**
          * Init AJAX jobs
@@ -83,12 +86,12 @@ namespace wpCloud\StatelessMedia {
         /**
          * Maybe Upgrade current Version
          */
-        Upgrader::call( $this->args[ 'version' ] );
+        Upgrader::call($this->args['version']);
 
         /**
          * Load WP-CLI Commands
          */
-        if( defined( 'WP_CLI' ) && WP_CLI ) {
+        if (defined('WP_CLI') && WP_CLI) {
           include_once($this->path('lib/cli/class-sm-cli-command.php', 'dir'));
         }
 
@@ -110,23 +113,23 @@ namespace wpCloud\StatelessMedia {
         /**
          * Add scripts
          */
-        add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
+        add_action('admin_enqueue_scripts', [$this, 'admin_enqueue_scripts']);
 
         /**
          * Hashify file name if option is enabled
          */
-        if ( $this->get( 'sm.hashify_file_name' ) == 'true' ) {
-          add_filter('sanitize_file_name', array( $this, 'randomize_filename' ), 10);
+        if ($this->get('sm.hashify_file_name') == 'true') {
+          add_filter('sanitize_file_name', [$this, 'randomize_filename'], 10);
         }
 
         /* Initialize plugin only if Mode is not 'disabled'. */
-        if ( $this->get( 'sm.mode' ) !== 'disabled' ) {
+        if ($this->get('sm.mode') !== 'disabled') {
 
           /**
            * Override Cache Control is option is enabled
            */
-          if ( $this->get( 'sm.override_cache_control' ) == 'true' ) {
-            add_filter( 'sm:item:cacheControl', array( $this, 'override_cache_control' ) );
+          if ($this->get('sm.override_cache_control') == 'true') {
+            add_filter('sm:item:cacheControl', [$this, 'override_cache_control']);
           }
 
           /**
@@ -135,64 +138,99 @@ namespace wpCloud\StatelessMedia {
            */
           $is_connected = $this->is_connected_to_gs();
 
-          if ( is_wp_error( $is_connected ) ) {
-            $this->errors->add( $is_connected->get_error_message() );
+          if (is_wp_error($is_connected)) {
+            $this->errors->add($is_connected->get_error_message());
           }
 
           /** Temporary fix to WP 4.4 srcset feature **/
-          add_filter( 'max_srcset_image_width', create_function( '', 'return 1;' ) );
+          add_filter('max_srcset_image_width', create_function('', 'return 1;'));
 
           /**
-           * Carry on only if we do not have errors.
+           * Carry on only if we do not have errors or mode is CDN Only
            */
-          if( !$this->has_errors() ) {
+          if (($this->get('sm.mode') === 'cdn' && !$this->has_errors()) || $this->get('sm.mode') === 'cdn_only') {
+            add_filter('wp_get_attachment_image_attributes',
+              [$this, 'wp_get_attachment_image_attributes'], 20, 3);
+            add_filter('wp_get_attachment_url', [$this, 'wp_get_attachment_url'], 20, 2);
+            add_filter('attachment_url_to_postid', [$this, 'attachment_url_to_postid'], 20, 2);
 
-            if( $this->get( 'sm.mode' ) === 'cdn' ) {
-              add_filter( 'wp_get_attachment_image_attributes', array( $this, 'wp_get_attachment_image_attributes' ), 20, 3 );
-              add_filter( 'wp_get_attachment_url', array( $this, 'wp_get_attachment_url' ), 20, 2 );
-              add_filter( 'attachment_url_to_postid', array( $this, 'attachment_url_to_postid' ), 20, 2 );
-
-              if ( $this->get( 'sm.body_rewrite' ) == 'true' ) {
-                add_filter( 'the_content', array( $this, 'the_content_filter' ) );
-              }
+            if ($this->get('sm.body_rewrite') == 'true') {
+              add_filter('the_content', [$this, 'the_content_filter']);
             }
+          }
 
-            if ( $root_dir = $this->get( 'sm.root_dir' ) ) {
-              if ( trim( $root_dir ) !== '' ) {
-                add_filter( 'wp_stateless_file_name', array( $this, 'handle_root_dir' ) );
+          /**
+           * Carry on only if we do not have errors or mode is CDN Only
+           */
+          if (!$this->has_errors() || $this->get('sm.mode') === 'cdn_only') {
+            if ($root_dir = $this->get('sm.root_dir')) {
+              if (trim($root_dir) !== '') {
+                add_filter('wp_stateless_file_name', [$this, 'handle_root_dir']);
               }
             }
 
             /**
              * Rewrite Image URLS
              */
-            add_filter( 'image_downsize', array( $this, 'image_downsize' ), 99, 3 );
+            add_filter('image_downsize', [$this, 'image_downsize'], 99, 3);
+          }
 
+          /**
+           * Methods for CDN only mode
+           */
+          if ($this->get('sm.mode') == 'cdn_only') {
+            if ($this->has_errors()) {
+              /**
+               * Prevent upload when we have an error from the GCS API
+               */
+              add_filter('wp_handle_upload_prefilter', [$this, 'wp_disable_upload_media']);
+
+              /**
+               * Prevent deletions when we have an error from the GCS API
+               */
+              add_filter('delete_attachment', [$this, 'wp_disable_delete_attachment'], -100);
+            }
+          }
+
+
+          /**
+           * Carry on only if we do not have errors.
+           */
+          if (!$this->has_errors()) {
             /**
              * Extends metadata by adding GS information.
              */
-            add_filter( 'wp_get_attachment_metadata', array( $this, 'wp_get_attachment_metadata' ), 10, 2 );
-            add_filter( 'wp_update_attachment_metadata', array( $this, 'add_media' ), 100, 2 );
+            add_filter('wp_get_attachment_metadata', [$this, 'wp_get_attachment_metadata'], 10, 2);
+            add_filter('wp_update_attachment_metadata', [$this, 'add_media'], 100, 2);
+
+
 
             /**
              * Add/Edit Media
              *
              * Once added or edited we can get into Attachment ID then get all image sizes and sync them with GS
              */
-            add_filter( 'wp_generate_attachment_metadata', array( $this, 'add_media' ), 100, 2 );
+            add_filter('wp_generate_attachment_metadata', [$this, 'add_media'], 100, 2);
 
-            if ( $this->get( 'sm.on_fly' ) == 'true' ) {
+            if ($this->get('sm.mode') == 'cdn_only') {
+              /**
+               * Deleting media from the local server after all
+               */
+              add_action("wp_generate_attachment_metadata", [$this, 'remove_local_media'], 101, 2);
+            }
+
+            if ($this->get('sm.on_fly') == 'true') {
               /**
                * Handle any other on fly generated media
                */
-              add_filter('image_make_intermediate_size', array($this, 'handle_on_fly'));
+              add_filter('image_make_intermediate_size', [$this, 'handle_on_fly']);
             }
 
-            if ( $this->get( 'sm.delete_remote' ) == 'true' ) {
+            if ($this->get('sm.delete_remote') == 'true') {
               /**
                * On physical file deletion we remove any from GS
                */
-              add_filter('delete_attachment', array($this, 'remove_media'));
+              add_filter('delete_attachment', [$this, 'remove_media']);
             }
           }
 
@@ -205,7 +243,8 @@ namespace wpCloud\StatelessMedia {
        * @param $new_blog
        * @param $prev_blog_id
        */
-      public function on_switch_blog( $new_blog, $prev_blog_id ) {
+      public function on_switch_blog($new_blog, $prev_blog_id)
+      {
         $this->settings->refresh();
       }
 
@@ -215,16 +254,21 @@ namespace wpCloud\StatelessMedia {
        * @param $detached
        * @return mixed
        */
-      public function add_custom_row_actions( $actions, $post, $detached ) {
+      public function add_custom_row_actions($actions, $post, $detached)
+      {
 
-        if ( !current_user_can( 'upload_files' ) ) return $actions;
-
-        if ( $post && 'attachment' == $post->post_type && 'image/' == substr( $post->post_mime_type, 0, 6 ) ) {
-          $actions['sm_sync'] = '<a href="javascript:;" data-id="'.$post->ID.'" data-type="image" class="sm_inline_sync">' . __('Regenerate and Sync with GCS', ud_get_stateless_media()->domain) . '</a>';
+        if (!current_user_can('upload_files')) {
+          return $actions;
         }
 
-        if ( $post && 'attachment' == $post->post_type && 'image/' != substr( $post->post_mime_type, 0, 6 ) ) {
-          $actions['sm_sync'] = '<a href="javascript:;" data-id="'.$post->ID.'" data-type="other" class="sm_inline_sync">' . __('Sync with GCS', ud_get_stateless_media()->domain) . '</a>';
+        if ($post && 'attachment' == $post->post_type && 'image/' == substr($post->post_mime_type, 0, 6)) {
+          $actions['sm_sync'] = '<a href="javascript:;" data-id="' . $post->ID . '" data-type="image" class="sm_inline_sync">' . __('Regenerate and Sync with GCS',
+              ud_get_stateless_media()->domain) . '</a>';
+        }
+
+        if ($post && 'attachment' == $post->post_type && 'image/' != substr($post->post_mime_type, 0, 6)) {
+          $actions['sm_sync'] = '<a href="javascript:;" data-id="' . $post->ID . '" data-type="other" class="sm_inline_sync">' . __('Sync with GCS',
+              ud_get_stateless_media()->domain) . '</a>';
         }
 
         return $actions;
@@ -234,11 +278,12 @@ namespace wpCloud\StatelessMedia {
       /**
        * Register metaboxes
        */
-      public function register_metaboxes() {
+      public function register_metaboxes()
+      {
         add_meta_box(
           'sm-attachment-metabox',
-          __( 'Google Cloud Storage', ud_get_stateless_media()->domain ),
-          array($this, 'attachment_meta_box_callback'),
+          __('Google Cloud Storage', ud_get_stateless_media()->domain),
+          [$this, 'attachment_meta_box_callback'],
           'attachment',
           'side',
           'low'
@@ -252,85 +297,95 @@ namespace wpCloud\StatelessMedia {
        *
        * @author potanin@UD
        */
-      public function api_init() {
+      public function api_init()
+      {
 
-        register_rest_route( 'wp-stateless/v1', '/status', array(
-          'methods' => 'GET',
-          'callback' => array( 'wpCloud\StatelessMedia\API', 'status' ),
-        ) );
+        register_rest_route('wp-stateless/v1', '/status', [
+          'methods'  => 'GET',
+          'callback' => ['wpCloud\StatelessMedia\API', 'status'],
+        ]);
 
-        register_rest_route( 'wp-stateless/v1', '/jobs', array(
-          'methods' => 'GET',
-          'callback' => array( 'wpCloud\StatelessMedia\API', 'jobs' ),
-        ) );
+        register_rest_route('wp-stateless/v1', '/jobs', [
+          'methods'  => 'GET',
+          'callback' => ['wpCloud\StatelessMedia\API', 'jobs'],
+        ]);
 
       }
 
       /**
        * @param $post
        */
-      public function attachment_meta_box_callback( $post ) {
+      public function attachment_meta_box_callback($post)
+      {
         ob_start();
 
-        $sm_cloud = get_post_meta( $post->ID, 'sm_cloud', 1 );
+        $sm_cloud = get_post_meta($post->ID, 'sm_cloud', 1);
 
-        if ( is_array( $sm_cloud ) && !empty( $sm_cloud[ 'fileLink' ] ) ) { ?>
+        if (is_array($sm_cloud) && !empty($sm_cloud['fileLink'])) { ?>
 
-          <?php if( !empty( $sm_cloud[ 'cacheControl' ] ) ) { ?>
-            <div class="misc-pub-cache-control hidden">
-              <?php _e( 'Cache Control:', ud_get_stateless_media()->domain ); ?> <strong><span><?php echo $sm_cloud[ 'cacheControl' ]; ?></span> </strong>
-            </div>
+          <?php if (!empty($sm_cloud['cacheControl'])) { ?>
+                <div class="misc-pub-cache-control hidden">
+                  <?php _e('Cache Control:', ud_get_stateless_media()->domain); ?>
+                    <strong><span><?php echo $sm_cloud['cacheControl']; ?></span> </strong>
+                </div>
           <?php } ?>
 
-          <div class="misc-pub-gs-file-link" style="margin-bottom: 15px;">
-            <label>
-              <?php _e( 'Storage Bucket URL:', ud_get_stateless_media()->domain ); ?> <a href="<?php echo $sm_cloud[ 'fileLink' ]; ?>" target="_blank" class="sm-view-link"><?php _e( '[view]' ); ?></a>
-              <input type="text" class="widefat urlfield" readonly="readonly" value="<?php echo esc_attr($sm_cloud[ 'fileLink' ]); ?>" />
-            </label>
-          </div>
+            <div class="misc-pub-gs-file-link" style="margin-bottom: 15px;">
+                <label>
+                  <?php _e('Storage Bucket URL:', ud_get_stateless_media()->domain); ?> <a
+                            href="<?php echo $sm_cloud['fileLink']; ?>" target="_blank"
+                            class="sm-view-link"><?php _e('[view]'); ?></a>
+                    <input type="text" class="widefat urlfield" readonly="readonly"
+                           value="<?php echo esc_attr($sm_cloud['fileLink']); ?>"/>
+                </label>
+            </div>
 
           <?php
 
-          if ( !empty( $sm_cloud[ 'bucket' ] ) ) {
+          if (!empty($sm_cloud['bucket'])) {
             ?>
-            <div class="misc-pub-gs-bucket" style="margin-bottom: 15px;">
-              <label>
-                <?php _e( 'Storage Bucket:', ud_get_stateless_media()->domain ); ?>
-                <input type="text" class="widefat urlfield" readonly="readonly" value="gs://<?php echo esc_attr($sm_cloud[ 'bucket' ]); ?>" />
-              </label>
-            </div>
+              <div class="misc-pub-gs-bucket" style="margin-bottom: 15px;">
+                  <label>
+                    <?php _e('Storage Bucket:', ud_get_stateless_media()->domain); ?>
+                      <input type="text" class="widefat urlfield" readonly="readonly"
+                             value="gs://<?php echo esc_attr($sm_cloud['bucket']); ?>"/>
+                  </label>
+              </div>
             <?php
           }
 
-          if ( current_user_can( 'upload_files' ) ) {
-            if ( $post && 'attachment' == $post->post_type && 'image/' == substr( $post->post_mime_type, 0, 6 ) ) {
+          if (current_user_can('upload_files')) {
+            if ($post && 'attachment' == $post->post_type && 'image/' == substr($post->post_mime_type, 0, 6)) {
               ?>
-              <a href="javascript:;" data-type="image" data-id="<?php echo $post->ID; ?>"
-                 class="button-secondary sm_inline_sync"><?php _e('Regenerate and Sync with GCS', ud_get_stateless_media()->domain); ?></a>
+                <a href="javascript:;" data-type="image" data-id="<?php echo $post->ID; ?>"
+                   class="button-secondary sm_inline_sync"><?php _e('Regenerate and Sync with GCS',
+                    ud_get_stateless_media()->domain); ?></a>
               <?php
             }
 
-            if ( $post && 'attachment' == $post->post_type && 'image/' != substr( $post->post_mime_type, 0, 6 ) ) {
+            if ($post && 'attachment' == $post->post_type && 'image/' != substr($post->post_mime_type, 0, 6)) {
               ?>
-              <a href="javascript:;" data-type="other" data-id="<?php echo $post->ID; ?>"
-                 class="button-secondary sm_inline_sync"><?php _e('Sync with GCS', ud_get_stateless_media()->domain); ?></a>
+                <a href="javascript:;" data-type="other" data-id="<?php echo $post->ID; ?>"
+                   class="button-secondary sm_inline_sync"><?php _e('Sync with GCS',
+                    ud_get_stateless_media()->domain); ?></a>
               <?php
             }
           }
         }
 
-        echo apply_filters( 'sm::attachment::meta', ob_get_clean(), $post->ID );
+        echo apply_filters('sm::attachment::meta', ob_get_clean(), $post->ID);
       }
 
       /**
        * @param $current_path
        * @return string
        */
-      public function handle_root_dir( $current_path ) {
-        $root_dir = $this->get( 'sm.root_dir' );
-        $root_dir = trim( $root_dir );
+      public function handle_root_dir($current_path)
+      {
+        $root_dir = $this->get('sm.root_dir');
+        $root_dir = trim($root_dir);
 
-        if ( !empty( $root_dir ) ) {
+        if (!empty($root_dir)) {
           return $root_dir . $current_path;
         }
 
@@ -341,20 +396,23 @@ namespace wpCloud\StatelessMedia {
        * @param $content
        * @return mixed
        */
-      public function the_content_filter( $content ) {
+      public function the_content_filter($content)
+      {
 
-        if ( $upload_data = wp_upload_dir() ) {
+        if ($upload_data = wp_upload_dir()) {
 
-          if ( !empty( $upload_data['baseurl'] ) && !empty( $content ) ) {
-            $baseurl = preg_replace('/https?:\/\//','',$upload_data['baseurl']);
-            $root_dir = trim( $this->get( 'sm.root_dir' ) );
-            $root_dir = !empty( $root_dir ) ? $root_dir : false;
+          if (!empty($upload_data['baseurl']) && !empty($content)) {
+            $baseurl = preg_replace('/https?:\/\//', '', $upload_data['baseurl']);
+            $root_dir = trim($this->get('sm.root_dir'));
+            $root_dir = !empty($root_dir) ? $root_dir : false;
             $image_host = 'storage.googleapis.com/';
-            if ( $this->get( 'sm.static_host' ) == 'true') {
-                $image_host = '';  // bucketname will be host
+            if ($this->get('sm.static_host') == 'true') {
+              $image_host = '';  // bucketname will be host
             }
-            $content = preg_replace( '/(href|src)=(\'|")(https?:\/\/'.str_replace('/', '\/', $baseurl).')\/(.+?)(\.jpg|\.png|\.gif|\.jpeg)(\'|")/i',
-                '$1=$2https://'.$image_host.$this->get( 'sm.bucket' ).'/'.($root_dir?$root_dir:'').'$4$5$6', $content);
+            $content = preg_replace('/(href|src)=(\'|")(https?:\/\/' . str_replace('/', '\/',
+                $baseurl) . ')\/(.+?)(\.jpg|\.png|\.gif|\.jpeg)(\'|")/i',
+              '$1=$2https://' . $image_host . $this->get('sm.bucket') . '/' . ($root_dir ? $root_dir : '') . '$4$5$6',
+              $content);
           }
         }
 
@@ -367,31 +425,33 @@ namespace wpCloud\StatelessMedia {
        * @param $file
        * @return mixed
        */
-      public function handle_on_fly( $file ) {
+      public function handle_on_fly($file)
+      {
 
         $client = ud_get_stateless_media()->get_client();
         $upload_dir = wp_upload_dir();
 
-        $file_path = str_replace( trailingslashit( $upload_dir[ 'basedir' ] ), '', $file );
-        $file_info = @getimagesize( $file );
+        $file_path = str_replace(trailingslashit($upload_dir['basedir']), '', $file);
+        $file_info = @getimagesize($file);
 
-        if ( $file_info ) {
-          $_metadata = array(
-            'width'  => $file_info[0],
-            'height' => $file_info[1],
+        if ($file_info) {
+          $_metadata = [
+            'width'     => $file_info[0],
+            'height'    => $file_info[1],
             'object-id' => 'unknown', // we really don't know it
-            'source-id' => md5( $file.ud_get_stateless_media()->get( 'sm.bucket' ) ),
-            'file-hash' => md5( $file )
-          );
+            'source-id' => md5($file . ud_get_stateless_media()->get('sm.bucket')),
+            'file-hash' => md5($file),
+          ];
         }
 
-        $client->add_media( apply_filters('sm:item:on_fly:before_add', array_filter( array(
-          'name' => $file_path,
-          'absolutePath' => wp_normalize_path( $file ),
-          'cacheControl' => apply_filters( 'sm:item:cacheControl', 'public, max-age=36000, must-revalidate', $_metadata ),
+        $client->add_media(apply_filters('sm:item:on_fly:before_add', array_filter([
+          'name'               => $file_path,
+          'absolutePath'       => wp_normalize_path($file),
+          'cacheControl'       => apply_filters('sm:item:cacheControl', 'public, max-age=36000, must-revalidate',
+            $_metadata),
           'contentDisposition' => null,
-          'metadata' => $_metadata
-        ) ) ) );
+          'metadata'           => $_metadata,
+        ])));
 
         return $file;
       }
@@ -401,16 +461,17 @@ namespace wpCloud\StatelessMedia {
        * @param $file
        * @return mixed
        */
-      public function plugin_action_links( $links, $file ) {
+      public function plugin_action_links($links, $file)
+      {
 
-        if ($file == plugin_basename( dirname( __DIR__ ) . '/wp-stateless-media.php' ) ) {
-          $settings_link = '<a href="'. '' .'">'.__( 'Settings' , 'ssd').'</a>';
-          array_unshift( $links, $settings_link );
+        if ($file == plugin_basename(dirname(__DIR__) . '/wp-stateless-media.php')) {
+          $settings_link = '<a href="' . '' . '">' . __('Settings', 'ssd') . '</a>';
+          array_unshift($links, $settings_link);
         }
 
-        if ($file == plugin_basename( dirname( __DIR__ ) . '/wp-stateless.php' ) ) {
-          $settings_link = '<a href="'. '' .'">'.__( 'Settings' , 'ssd').'</a>';
-          array_unshift( $links, $settings_link );
+        if ($file == plugin_basename(dirname(__DIR__) . '/wp-stateless.php')) {
+          $settings_link = '<a href="' . '' . '">' . __('Settings', 'ssd') . '</a>';
+          array_unshift($links, $settings_link);
         }
 
         return $links;
@@ -422,14 +483,15 @@ namespace wpCloud\StatelessMedia {
        *
        * @author peshkov@UD
        */
-      public function is_network_detected() {
+      public function is_network_detected()
+      {
         /* Plugin is loaded via mu-plugins. */
 
-        if( strpos( Utility::normalize_path( $this->root_path ), Utility::normalize_path( WPMU_PLUGIN_DIR ) ) !== false ) {
+        if (strpos(Utility::normalize_path($this->root_path), Utility::normalize_path(WPMU_PLUGIN_DIR)) !== false) {
           return true;
         }
 
-        if( is_multisite() ) {
+        if (is_multisite()) {
           /* Looks through network enabled plugins to see if our one is there. */
           foreach (wp_get_active_network_plugins() as $path) {
             if ($this->boot_file == $path) {
@@ -437,6 +499,7 @@ namespace wpCloud\StatelessMedia {
             }
           }
         }
+
         return false;
       }
 
@@ -445,21 +508,25 @@ namespace wpCloud\StatelessMedia {
        * @todo: it should not be loaded everywhere. peshkov@UD
        * @param $hook
        */
-      public function admin_enqueue_scripts( $hook ) {
+      public function admin_enqueue_scripts($hook)
+      {
 
-        wp_enqueue_style( 'wp-stateless', $this->path( 'static/styles/wp-stateless.css', 'url'  ), array(), self::$version );
+        wp_enqueue_style('wp-stateless', $this->path('static/styles/wp-stateless.css', 'url'), [], self::$version);
 
-        switch( $hook ) {
+        switch ($hook) {
 
           case 'options-media.php':
             //wp_enqueue_script( 'wp-api' );
 
-            wp_enqueue_script( 'wp-stateless-setup', ud_get_stateless_media()->path( 'static/scripts/wp-stateless-setup.js', 'url'  ), array( 'jquery-ui-core', 'wp-api' ), ud_get_stateless_media()->version, true );
-          break;
+            wp_enqueue_script('wp-stateless-setup',
+              ud_get_stateless_media()->path('static/scripts/wp-stateless-setup.js', 'url'),
+              ['jquery-ui-core', 'wp-api'], ud_get_stateless_media()->version, true);
+            break;
 
           case 'upload.php':
 
-            wp_enqueue_script( 'wp-stateless-uploads-js', $this->path( 'static/scripts/wp-stateless-uploads.js', 'url'  ), array( 'jquery' ), self::$version );
+            wp_enqueue_script('wp-stateless-uploads-js', $this->path('static/scripts/wp-stateless-uploads.js', 'url'),
+              ['jquery'], self::$version);
 
             break;
 
@@ -467,25 +534,47 @@ namespace wpCloud\StatelessMedia {
 
             global $post;
 
-            if ( $post->post_type == 'attachment' ) {
-              wp_enqueue_script( 'wp-stateless-uploads-js', $this->path( 'static/scripts/wp-stateless-uploads.js', 'url'  ), array( 'jquery' ), self::$version );
+            if ($post->post_type == 'attachment') {
+              wp_enqueue_script('wp-stateless-uploads-js', $this->path('static/scripts/wp-stateless-uploads.js', 'url'),
+                ['jquery'], self::$version);
             }
 
             break;
 
           case $this->settings->setup_wizard_ui:
-            wp_enqueue_style( 'wp-stateless-bootstrap', $this->path( 'static/styles/bootstrap.min.css', 'url'  ), array(), '3.3.7' );
-            wp_enqueue_style( 'wp-stateless-setup-wizard', $this->path( 'static/styles/wp-stateless-setup-wizard.css', 'url'  ), array(), self::$version );
+            wp_enqueue_style('wp-stateless-bootstrap', $this->path('static/styles/bootstrap.min.css', 'url'), [],
+              '3.3.7');
+            wp_enqueue_style('wp-stateless-setup-wizard',
+              $this->path('static/styles/wp-stateless-setup-wizard.css', 'url'), [], self::$version);
 
-            wp_enqueue_script( 'jquery.history', ud_get_stateless_media()->path( 'static/scripts/jquery.history.js', 'url'  ), array( 'jquery' ), ud_get_stateless_media()->version, true );
-            wp_enqueue_script( 'wp-stateless-validation', ud_get_stateless_media()->path( 'static/scripts/jquery.validation.js', 'url'  ), array( 'jquery' ), ud_get_stateless_media()->version, true );
-            wp_enqueue_script( 'wp-stateless-loading', ud_get_stateless_media()->path( 'static/scripts/jquery.loading.js', 'url'  ), array( 'jquery' ), ud_get_stateless_media()->version, true );
-            wp_enqueue_script( 'wp-stateless-comboBox', ud_get_stateless_media()->path( 'static/scripts/jquery.wpStateLess-combo-box.js', 'url'  ), array( 'jquery' ), ud_get_stateless_media()->version, true );
-            wp_enqueue_script( 'wp-stateless-setup', ud_get_stateless_media()->path( 'static/scripts/wp-stateless-setup.js', 'url'  ), array( 'jquery-ui-core', 'wp-api', 'jquery.history' ), ud_get_stateless_media()->version, true );
-            wp_enqueue_script( 'wp-stateless-setup-wizard-js', ud_get_stateless_media()->path( 'static/scripts/wp-stateless-setup-wizard.js', 'url'  ), array( 'jquery', 'wp-api', 'wp-stateless-setup', 'wp-stateless-comboBox', 'wp-stateless-validation', 'wp-stateless-loading' ), ud_get_stateless_media()->version, true );
+            wp_enqueue_script('jquery.history',
+              ud_get_stateless_media()->path('static/scripts/jquery.history.js', 'url'), ['jquery'],
+              ud_get_stateless_media()->version, true);
+            wp_enqueue_script('wp-stateless-validation',
+              ud_get_stateless_media()->path('static/scripts/jquery.validation.js', 'url'), ['jquery'],
+              ud_get_stateless_media()->version, true);
+            wp_enqueue_script('wp-stateless-loading',
+              ud_get_stateless_media()->path('static/scripts/jquery.loading.js', 'url'), ['jquery'],
+              ud_get_stateless_media()->version, true);
+            wp_enqueue_script('wp-stateless-comboBox',
+              ud_get_stateless_media()->path('static/scripts/jquery.wpStateLess-combo-box.js', 'url'), ['jquery'],
+              ud_get_stateless_media()->version, true);
+            wp_enqueue_script('wp-stateless-setup',
+              ud_get_stateless_media()->path('static/scripts/wp-stateless-setup.js', 'url'),
+              ['jquery-ui-core', 'wp-api', 'jquery.history'], ud_get_stateless_media()->version, true);
+            wp_enqueue_script('wp-stateless-setup-wizard-js',
+              ud_get_stateless_media()->path('static/scripts/wp-stateless-setup-wizard.js', 'url'), [
+                'jquery',
+                'wp-api',
+                'wp-stateless-setup',
+                'wp-stateless-comboBox',
+                'wp-stateless-validation',
+                'wp-stateless-loading',
+              ], ud_get_stateless_media()->version, true);
             break;
 
-          default: break;
+          default:
+            break;
         }
 
       }
@@ -499,14 +588,15 @@ namespace wpCloud\StatelessMedia {
        * @param $size
        * @return mixed
        */
-      public function wp_get_attachment_image_attributes( $attr, $attachment, $size ) {
+      public function wp_get_attachment_image_attributes($attr, $attachment, $size)
+      {
 
-        $sm_cloud = get_post_meta( $attachment->ID, 'sm_cloud', true );
-        if( is_array( $sm_cloud ) && !empty( $sm_cloud[ 'name' ] ) ) {
-          $attr[ 'class' ] = $attr[ 'class' ] . ' wp-stateless-item';
-          $attr[ 'data-image-size' ] = is_array( $size ) ? implode( 'x', $size ) : $size;
-          $attr[ 'data-stateless-media-bucket' ] = isset( $sm_cloud[ 'bucket' ] ) ? $sm_cloud[ 'bucket' ] : false;
-          $attr[ 'data-stateless-media-name' ] = $sm_cloud[ 'name' ];
+        $sm_cloud = get_post_meta($attachment->ID, 'sm_cloud', true);
+        if (is_array($sm_cloud) && !empty($sm_cloud['name'])) {
+          $attr['class'] = $attr['class'] . ' wp-stateless-item';
+          $attr['data-image-size'] = is_array($size) ? implode('x', $size) : $size;
+          $attr['data-stateless-media-bucket'] = isset($sm_cloud['bucket']) ? $sm_cloud['bucket'] : false;
+          $attr['data-stateless-media-name'] = $sm_cloud['name'];
         }
 
         return $attr;
@@ -519,8 +609,10 @@ namespace wpCloud\StatelessMedia {
        * @param $views
        * @return mixed
        */
-      public function views_upload( $views ) {
-        $views['stateless'] = '<a href="#">' . __( 'Stateless Media' ) . '</a>';
+      public function views_upload($views)
+      {
+        $views['stateless'] = '<a href="#">' . __('Stateless Media') . '</a>';
+
         return $views;
       }
 
@@ -532,16 +624,17 @@ namespace wpCloud\StatelessMedia {
        * @param string $size
        * @return mixed $false
        */
-      public function image_downsize( $false = false, $id, $size ) {
+      public function image_downsize($false = false, $id, $size)
+      {
 
-        if ( !isset( $this->client ) || !$this->client || is_wp_error( $this->client ) ) {
+        if (!isset($this->client) || !$this->client || is_wp_error($this->client)) {
           return $false;
         }
 
         /**
          * Check if enabled
          */
-        if ( $this->get( 'sm.mode' ) !== 'cdn' ) {
+        if ($this->get('sm.mode') !== 'cdn') {
           return $false;
         }
 
@@ -552,36 +645,35 @@ namespace wpCloud\StatelessMedia {
         $is_intermediate = false;
 
         //** try for a new style intermediate size */
-        if ( $intermediate = image_get_intermediate_size( $id, $size ) ) {
-          $img_url = !empty( $intermediate['gs_link'] ) ? $intermediate['gs_link'] : $intermediate['url'];
+        if ($intermediate = image_get_intermediate_size($id, $size)) {
+          $img_url = !empty($intermediate['gs_link']) ? $intermediate['gs_link'] : $intermediate['url'];
           $width = $intermediate['width'];
           $height = $intermediate['height'];
           $is_intermediate = true;
         }
-        //die( '<pre>' . print_r( $intermediate, true ) . '</pre>' );
 
         /**
          * maybe try to get images info from sm_cloud
          * this case may happen when no local files
          * @author korotkov@ud
          */
-        if ( !$width && !$height ) {
-          $sm_cloud = get_post_meta( $id, 'sm_cloud', true );
-          if ( is_string($size) && !empty( $sm_cloud['sizes'] ) && !empty( $sm_cloud['sizes'][$size] ) ) {
+        if (!$width && !$height) {
+          $sm_cloud = get_post_meta($id, 'sm_cloud', true);
+          if (is_string($size) && !empty($sm_cloud['sizes']) && !empty($sm_cloud['sizes'][$size])) {
             global $_wp_additional_image_sizes;
 
-            $img_url = !empty( $sm_cloud['sizes'][$size]['fileLink'] ) ? $sm_cloud['sizes'][$size]['fileLink'] : $img_url;
+            $img_url = !empty($sm_cloud['sizes'][$size]['fileLink']) ? $sm_cloud['sizes'][$size]['fileLink'] : $img_url;
 
-            if ( !empty( $_wp_additional_image_sizes[ $size ] ) ) {
-              $width = !empty( $_wp_additional_image_sizes[ $size ]['width'] ) ? $_wp_additional_image_sizes[ $size ]['width'] : $width;
-              $height = !empty( $_wp_additional_image_sizes[ $size ]['height'] ) ? $_wp_additional_image_sizes[ $size ]['height'] : $height;
+            if (!empty($_wp_additional_image_sizes[$size])) {
+              $width = !empty($_wp_additional_image_sizes[$size]['width']) ? $_wp_additional_image_sizes[$size]['width'] : $width;
+              $height = !empty($_wp_additional_image_sizes[$size]['height']) ? $_wp_additional_image_sizes[$size]['height'] : $height;
             }
 
             $is_intermediate = true;
           }
         }
 
-        if ( !$width && !$height && isset( $meta['width'], $meta['height'] ) ) {
+        if (!$width && !$height && isset($meta['width'], $meta['height'])) {
 
           //** any other type: use the real image */
           $width = $meta['width'];
@@ -589,12 +681,12 @@ namespace wpCloud\StatelessMedia {
         }
 
 
-        if ( $img_url) {
+        if ($img_url) {
 
           //** we have the actual image size, but might need to further constrain it if content_width is narrower */
-          list( $width, $height ) = image_constrain_size_for_editor( $width, $height, $size );
+          list($width, $height) = image_constrain_size_for_editor($width, $height, $size);
 
-          return array( $img_url, $width, $height, $is_intermediate );
+          return [$img_url, $width, $height, $is_intermediate];
         }
 
 
@@ -614,18 +706,19 @@ namespace wpCloud\StatelessMedia {
        * @param $attachment_id
        * @return $metadata
        */
-      public function wp_get_attachment_metadata( $metadata, $attachment_id  ) {
+      public function wp_get_attachment_metadata($metadata, $attachment_id)
+      {
         /* Determine if the media file has GS data at all. */
-        $sm_cloud = get_post_meta( $attachment_id, 'sm_cloud', true );
-        if( is_array( $sm_cloud ) && !empty( $sm_cloud[ 'fileLink' ] ) ) {
-          $metadata[ 'gs_link' ] = $sm_cloud[ 'fileLink' ];
-          $metadata[ 'gs_name' ] = isset( $sm_cloud[ 'name' ] ) ? $sm_cloud[ 'name' ] : false;
-          $metadata[ 'gs_bucket' ] = isset( $sm_cloud[ 'bucket' ] ) ? $sm_cloud[ 'bucket' ] : false;
-          if( !empty( $metadata[ 'sizes' ] ) && is_array( $metadata[ 'sizes' ] ) ) {
-            foreach( $metadata[ 'sizes' ] as $k => $v ) {
-              if( !empty( $sm_cloud[ 'sizes' ][ $k ][ 'name' ] ) ) {
-                $metadata['sizes'][$k]['gs_name'] = $sm_cloud[ 'sizes' ][ $k ][ 'name' ];
-                $metadata['sizes'][$k]['gs_link'] = $sm_cloud[ 'sizes' ][ $k ][ 'fileLink' ];
+        $sm_cloud = get_post_meta($attachment_id, 'sm_cloud', true);
+        if (is_array($sm_cloud) && !empty($sm_cloud['fileLink'])) {
+          $metadata['gs_link'] = $sm_cloud['fileLink'];
+          $metadata['gs_name'] = isset($sm_cloud['name']) ? $sm_cloud['name'] : false;
+          $metadata['gs_bucket'] = isset($sm_cloud['bucket']) ? $sm_cloud['bucket'] : false;
+          if (!empty($metadata['sizes']) && is_array($metadata['sizes'])) {
+            foreach ($metadata['sizes'] as $k => $v) {
+              if (!empty($sm_cloud['sizes'][$k]['name'])) {
+                $metadata['sizes'][$k]['gs_name'] = $sm_cloud['sizes'][$k]['name'];
+                $metadata['sizes'][$k]['gs_link'] = $sm_cloud['sizes'][$k]['fileLink'];
               }
             }
           }
@@ -641,20 +734,21 @@ namespace wpCloud\StatelessMedia {
        * @author peshkov@UD
        * @return object $this->client. \wpCloud\StatelessMedia\GS_Client or \WP_Error
        */
-      public function get_client() {
+      public function get_client()
+      {
 
-        if( null === $this->client ) {
+        if (null === $this->client) {
 
-          $key_json = get_site_option( 'sm_key_json' );
-          if ( empty($key_json) ) {
-            $key_json = $this->get( 'sm.key_json' );
+          $key_json = get_site_option('sm_key_json');
+          if (empty($key_json)) {
+            $key_json = $this->get('sm.key_json');
           }
 
           /* Try to initialize GS Client */
-          $this->client = GS_Client::get_instance( array(
-            'bucket' => $this->get( 'sm.bucket' ),
-            'key_json' => $key_json
-          ) );
+          $this->client = GS_Client::get_instance([
+            'bucket'   => $this->get('sm.bucket'),
+            'key_json' => $key_json,
+          ]);
         }
 
         return $this->client;
@@ -666,31 +760,35 @@ namespace wpCloud\StatelessMedia {
        *
        * @author peshkov@UD
        */
-      public function is_connected_to_gs() {
+      public function is_connected_to_gs()
+      {
 
-        $trnst = get_transient( 'sm::is_connected_to_gs' );
+        $trnst = get_transient('sm::is_connected_to_gs');
 
-        if ( empty($trnst) || false === $trnst || !isset( $trnst[ 'hash' ] ) || $trnst[ 'hash' ] != md5( serialize( $this->get( 'sm' ) ) ) ) {
-          $trnst = array(
+        if (empty($trnst) || false === $trnst || !isset($trnst['hash']) || $trnst['hash'] != md5(serialize($this->get('sm')))) {
+          $trnst = [
             'success' => 'true',
-            'error' => '',
-            'hash' => md5( serialize( $this->get( 'sm' ) ) ),
-          );
+            'error'   => '',
+            'hash'    => md5(serialize($this->get('sm'))),
+          ];
           $client = $this->get_client();
-          if ( is_wp_error( $client ) ) {
-            $trnst[ 'success' ] = 'false';
-            $trnst[ 'error' ] = $client->get_error_message();
+          if (is_wp_error($client)) {
+            $trnst['success'] = 'false';
+            $trnst['error'] = $client->get_error_message();
           } else {
-            if( !$client->is_connected() ) {
-              $trnst[ 'success' ] = 'false';
-              $trnst[ 'error' ] = sprintf( __( 'Could not connect to Google Storage bucket. Please, be sure that bucket with name <b>%s</b> exists.', $this->domain ), $this->get( 'sm.bucket' ) );
+            if (!$client->is_connected()) {
+              $trnst['success'] = 'false';
+              $trnst['error'] = sprintf(__('Could not connect to Google Storage bucket. Please, be sure that bucket with name <b>%s</b> exists.',
+                $this->domain), $this->get('sm.bucket'));
             }
           }
-          set_transient( 'sm::is_connected_to_gs', $trnst, 24 * HOUR_IN_SECONDS );
+          set_transient('sm::is_connected_to_gs', $trnst, 24 * HOUR_IN_SECONDS);
         }
 
-        if( isset( $trnst[ 'success' ] ) && $trnst[ 'success' ] == 'false' ) {
-          return new \WP_Error( 'error', ( !empty( $trnst[ 'error' ] ) ? $trnst[ 'error' ] : __( 'There is an Error on connection to Google Storage.', $this->domain ) ) );
+        if (isset($trnst['success']) && $trnst['success'] == 'false') {
+          return new \WP_Error('error',
+            (!empty($trnst['error']) ? $trnst['error'] : __('There is an Error on connection to Google Storage.',
+              $this->domain)));
         }
 
         return true;
@@ -700,22 +798,25 @@ namespace wpCloud\StatelessMedia {
        * Flush all plugin transients
        *
        */
-      public function flush_transients() {
-        delete_transient( 'sm::is_connected_to_gs' );
+      public function flush_transients()
+      {
+        delete_transient('sm::is_connected_to_gs');
       }
 
       /**
        * Plugin Activation
        *
        */
-      public function activate() {
-        add_action( 'activated_plugin', array($this, 'redirect_to_splash') );
+      public function activate()
+      {
+        add_action('activated_plugin', [$this, 'redirect_to_splash']);
         wp_redirect(admin_url('upload.php?page=stateless-setup-wizard&step=splash-screen'));
       }
 
-      public function redirect_to_splash($plugin =''){
-        if( $plugin == plugin_basename( $this->boot_file ) ) {
-          exit( wp_redirect(admin_url('upload.php?page=stateless-setup-wizard&step=splash-screen')));
+      public function redirect_to_splash($plugin = '')
+      {
+        if ($plugin == plugin_basename($this->boot_file)) {
+          exit(wp_redirect(admin_url('upload.php?page=stateless-setup-wizard&step=splash-screen')));
         }
       }
 
@@ -723,7 +824,9 @@ namespace wpCloud\StatelessMedia {
        * Plugin Deactivation
        *
        */
-      public function deactivate() {}
+      public function deactivate()
+      {
+      }
 
       /**
        * Filter for wp_get_attachment_url();
@@ -732,28 +835,93 @@ namespace wpCloud\StatelessMedia {
        * @param string $post_id
        * @return mixed|null|string
        */
-      public function wp_get_attachment_url( $url = '', $post_id = '' ) {
-        $sm_cloud = get_post_meta( $post_id, 'sm_cloud', 1 );
-        if( is_array( $sm_cloud ) && !empty( $sm_cloud[ 'fileLink' ] ) ) {
-          return strpos( $sm_cloud[ 'fileLink' ], 'https://' ) === false ? ( 'https:' . $sm_cloud[ 'fileLink' ] ) : $sm_cloud[ 'fileLink' ];
+      public function wp_get_attachment_url($url = '', $post_id = '')
+      {
+        $sm_cloud = get_post_meta($post_id, 'sm_cloud', 1);
+        if (is_array($sm_cloud) && !empty($sm_cloud['fileLink'])) {
+          return strpos($sm_cloud['fileLink'],
+            'https://') === false ? ('https:' . $sm_cloud['fileLink']) : $sm_cloud['fileLink'];
         }
+
         return $url;
       }
 
       /**
+       * Disable upload for some reason
+       *
+       * @author nks
+       * @param $file
+       * @return mixed
+       */
+      public function wp_disable_upload_media($file)
+      {
+        $file['error'] = __('Upload unavailable');
+
+        return $file;
+      }
+
+
+      /**
+       * Remove local media without deleting it from the database or GCS
+       *
+       * @param array $metadata
+       * @param $attachment_id
+       */
+      public function remove_local_media($metadata = array(), $attachment_id)
+      {
+        try {
+          $attachment = get_attached_file($attachment_id);
+
+          // Just remove file
+          if( $attachment && file_exists( $attachment ) ) {
+            unlink($attachment);
+          }
+
+          // Removing all sizes. They are not needed anymore
+          if(isset($metadata['sizes']) && $attachment){
+            $filePath = dirname($attachment);
+            foreach($metadata['sizes'] as $size){
+              if($size['file']) {
+                $sizeFullPath = $filePath . DIRECTORY_SEPARATOR . $size['file'];
+                if(file_exists($sizeFullPath)){
+                  unlink($sizeFullPath);
+                }
+              }
+            }
+          }
+        }catch(\Exception $exception){
+        }
+      }
+
+      /**
+       * Prevent deletion of the attachment
+       *
+       * @author nks
+       * @param $post_id
+       * @return bool
+       */
+      function wp_disable_delete_attachment($post_id)
+      {
+        wp_die(__('Delete attachment unavailable'));
+
+        return false;
+      }
+
+      /**
        * Filter for attachment_url_to_postid()
-       * 
+       *
        * @param int|false $post_id originally found post ID (or false if not found)
        * @param string $url the URL to find the post ID for
        * @return int|false found post ID from cloud storage URL
        */
-      public function attachment_url_to_postid( $post_id, $url ) {
+      public function attachment_url_to_postid($post_id, $url)
+      {
         global $wpdb;
 
-        if ( ! $post_id ) {
+        if (!$post_id) {
           $query = "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = 'sm_cloud' AND meta_value LIKE '%s'";
 
-          $post_id = $wpdb->get_var( $wpdb->prepare( $query, '%' . $url . '%' ) );
+          $post_id = $wpdb->get_var($wpdb->prepare($query, '%' . $url . '%'));
         }
 
         return $post_id;
@@ -765,15 +933,16 @@ namespace wpCloud\StatelessMedia {
        * @param $data
        * @return mixed
        */
-      public function upload_dir( $data ) {
+      public function upload_dir($data)
+      {
 
         $image_host = 'https://storage.googleapis.com/';
-        if ( ud_get_stateless_media()->get( 'sm.static_host' ) == 'true' ) {
+        if (ud_get_stateless_media()->get('sm.static_host') == 'true') {
           $image_host = 'https://';
         }
 
-        $data[ 'baseurl' ] = $image_host . ( $this->get( 'sm.bucket' ) );
-        $data[ 'url' ] = $data[ 'baseurl' ] . $data[ 'subdir' ];
+        $data['baseurl'] = $image_host . ($this->get('sm.bucket'));
+        $data['url'] = $data['baseurl'] . $data['subdir'];
 
         return $data;
 
@@ -787,40 +956,41 @@ namespace wpCloud\StatelessMedia {
        * @author potanin@UD
        * @return array|mixed|null|object
        */
-      public function parse_feature_flags( ) {
+      public function parse_feature_flags()
+      {
 
         try {
 
-          $_raw = file_get_contents( Utility::normalize_path( $this->root_path ) . 'composer.json' );
+          $_raw = file_get_contents(Utility::normalize_path($this->root_path) . 'composer.json');
 
-          $_parsed = json_decode( $_raw  );
+          $_parsed = json_decode($_raw);
 
           // @todo Catch poorly formatted JSON.
-          if( !is_object( $_parsed  ) ) {
+          if (!is_object($_parsed)) {
             // throw new Error( "unable to parse."  );
           }
 
-          foreach( (array) $_parsed->extra->featureFlags as $_feature ) {
+          foreach ((array)$_parsed->extra->featureFlags as $_feature) {
 
-            if( !defined( $_feature->constant  ) ) {
-              define( $_feature->constant, $_feature->enabled );
+            if (!defined($_feature->constant)) {
+              define($_feature->constant, $_feature->enabled);
 
-              if( $_feature->enabled ) {
-                Utility::log( 'Feature flag ' . $_feature->name . ', [' . $_feature->constant . '] enabled.' );
+              if ($_feature->enabled) {
+                Utility::log('Feature flag ' . $_feature->name . ', [' . $_feature->constant . '] enabled.');
               } else {
-                Utility::log( 'Feature flag ' . $_feature->name . ', [' . $_feature->constant . '] disabled.' );
+                Utility::log('Feature flag ' . $_feature->name . ', [' . $_feature->constant . '] disabled.');
               }
             }
 
           }
 
-        } catch ( Exception $e ) {
-          Utility::log( 'Unable to parse [composer.json] feature flags. Error: [' . $e->getMessage() . ']' );
+        } catch (Exception $e) {
+          Utility::log('Unable to parse [composer.json] feature flags. Error: [' . $e->getMessage() . ']');
           // echo 'Caught exception: ', $e->getMessage(), "\n";
         }
 
 
-        return isset( $_parsed ) ? $_parsed : null;
+        return isset($_parsed) ? $_parsed : null;
 
 
       }
@@ -834,11 +1004,12 @@ namespace wpCloud\StatelessMedia {
        * @param $arguments
        * @return mixed|null
        */
-      public function __call( $name, $arguments ) {
-        if( is_callable( array( "wpCloud\\StatelessMedia\\Utility", $name ) ) ) {
-          return call_user_func_array( array( "wpCloud\\StatelessMedia\\Utility", $name ), $arguments );
+      public function __call($name, $arguments)
+      {
+        if (is_callable(["wpCloud\\StatelessMedia\\Utility", $name])) {
+          return call_user_func_array(["wpCloud\\StatelessMedia\\Utility", $name], $arguments);
         } else {
-          return NULL;
+          return null;
         }
       }
 

--- a/lib/classes/class-gs-client.php
+++ b/lib/classes/class-gs-client.php
@@ -86,12 +86,12 @@ namespace wpCloud\StatelessMedia {
       public function list_objects( $bucket, $options = array() ) {
 
         $options = wp_parse_args( $options, array(
-            'delimiter'  => '',
-            'maxResults' => 1000,
-            'pageToken'  => '',
-            'prefix'     => '',
-            'projection' => 'noAcl',
-            'versions'   => false
+          'delimiter'  => '',
+          'maxResults' => 1000,
+          'pageToken'  => '',
+          'prefix'     => '',
+          'projection' => 'noAcl',
+          'versions'   => false
         ) );
 
         return $this->service->objects->listObjects( $bucket, $options );
@@ -125,13 +125,13 @@ namespace wpCloud\StatelessMedia {
           return $this->temp_objects;
         }
       }
-      
+
       /**
        * Add/Update Media Object to Bucket
        *
        * @author peshkov@UD
        * @param array $args
-       * @return bool
+       * @return array|WP_Error
        */
       public function add_media( $args = array() ) {
         try {
@@ -180,10 +180,10 @@ namespace wpCloud\StatelessMedia {
 
           /* Upload Media file to Google storage */
           $media = $this->service->objects->insert($this->bucket, $media, array_filter(array(
-              'data' => file_get_contents($args['absolutePath']),
-              'uploadType' => 'media',
-              'mimeType' => $args['mimeType'],
-              'predefinedAcl' => 'bucketOwnerFullControl',
+            'data' => file_get_contents($args['absolutePath']),
+            'uploadType' => 'media',
+            'mimeType' => $args['mimeType'],
+            'predefinedAcl' => 'bucketOwnerFullControl',
           )));
 
           /* Make Media Public READ for all on success */
@@ -230,7 +230,7 @@ namespace wpCloud\StatelessMedia {
       /**
        * Check if media exists
        * @param $path
-       * @return bool
+       * @return bool|\Google_Service_Storage_StorageObject
        */
       public function media_exists( $path ) {
         try {
@@ -244,7 +244,7 @@ namespace wpCloud\StatelessMedia {
         if ( empty( $media->id ) ) return false;
         return $media;
       }
-      
+
       /**
        * Fired for every file remove action
        *

--- a/lib/classes/class-settings.php
+++ b/lib/classes/class-settings.php
@@ -206,7 +206,14 @@ namespace wpCloud\StatelessMedia {
        * Draw interface
        */
       public function regenerate_interface() {
-        include ud_get_stateless_media()->path( '/static/views/regenerate_interface.php', 'dir' );
+        $_mode = get_site_option( 'sm_mode' );
+
+        if($_mode == 'cdn_only'){
+          echo __('Regenerate unavailable on <strong>CDN only</strong> mode', ud_get_stateless_media()->domain);
+        }else{
+          include ud_get_stateless_media()->path( '/static/views/regenerate_interface.php', 'dir' );
+        }
+
       }
 
       /**
@@ -220,7 +227,7 @@ namespace wpCloud\StatelessMedia {
           case 'finish':
             include ud_get_stateless_media()->path( '/static/views/setup_wizard_interface.php', 'dir' );
             break;
-          
+
           default:
             include ud_get_stateless_media()->path( '/static/views/stateless_splash_screen.php', 'dir' );
             break;
@@ -248,17 +255,17 @@ namespace wpCloud\StatelessMedia {
        */
       public function register_network_settings() {
         ?>
-        <h3 id="stateless-media-settings"><?php _e( 'Stateless Media Settings', ud_get_stateless_media()->domain ); ?></h3>
-        <p><?php $this->section_callback(); ?></p>
-        <div class="key_type"><label><b><?php _e('Service Account JSON', ud_get_stateless_media()->domain) ?></b></label>
-          <div class="_key_type _sm_key_json">
-            <textarea id="sm_key_json" class="field regular-textarea sm_key_json" type="text" name="sm[key_json]"><?php echo get_site_option( 'sm_key_json' ); ?></textarea>
+          <h3 id="stateless-media-settings"><?php _e( 'Stateless Media Settings', ud_get_stateless_media()->domain ); ?></h3>
+          <p><?php $this->section_callback(); ?></p>
+          <div class="key_type"><label><b><?php _e('Service Account JSON', ud_get_stateless_media()->domain) ?></b></label>
+              <div class="_key_type _sm_key_json">
+                  <textarea id="sm_key_json" class="field regular-textarea sm_key_json" type="text" name="sm[key_json]"><?php echo get_site_option( 'sm_key_json' ); ?></textarea>
+              </div>
           </div>
-        </div>
 
-        <div class="sm_mode">
-         <label><b><?php _e('Mode', ud_get_stateless_media()->domain); ?></b></label>
-          <?php
+          <div class="sm_mode">
+              <label><b><?php _e('Mode', ud_get_stateless_media()->domain); ?></b></label>
+            <?php
 
             $_mode = get_site_option( 'sm_mode' );
 
@@ -273,27 +280,27 @@ namespace wpCloud\StatelessMedia {
               . '<small class="description">'.__('Push media files to Google Storage and use them directly from there.', ud_get_stateless_media()->domain).'</small></label></p>'
             );
             echo implode( "\n", (array)apply_filters( 'sm::network::settings::mode', $inputs ) );
-          ?>
-        </div>
+            ?>
+          </div>
 
-        <div class="sm_advanced">
-          <label><b><?php _e('Advanced', ud_get_stateless_media()->domain); ?></b></label>
-          <?php
+          <div class="sm_advanced">
+              <label><b><?php _e('Advanced', ud_get_stateless_media()->domain); ?></b></label>
+            <?php
 
-          $_delete_remote = get_site_option( 'sm_delete_remote' );
+            $_delete_remote = get_site_option( 'sm_delete_remote' );
 
-          $inputs = array();
-          $inputs[] = '<p><input type="hidden" name="sm[delete_remote]" value="0" />';
-          $inputs[] = '<label for="sm_delete_remote"><input id="sm_delete_remote" type="checkbox" name="sm[delete_remote]" value="1" '. checked( '1', $_delete_remote, false ) .'/>'.__( 'Delete media from GCS when media is deleted from the site.', ud_get_stateless_media()->domain ).'<small> '.__( '(This option may slow down media deletion process)', ud_get_stateless_media()->domain ).'</small></label></p>';
+            $inputs = array();
+            $inputs[] = '<p><input type="hidden" name="sm[delete_remote]" value="0" />';
+            $inputs[] = '<label for="sm_delete_remote"><input id="sm_delete_remote" type="checkbox" name="sm[delete_remote]" value="1" '. checked( '1', $_delete_remote, false ) .'/>'.__( 'Delete media from GCS when media is deleted from the site.', ud_get_stateless_media()->domain ).'<small> '.__( '(This option may slow down media deletion process)', ud_get_stateless_media()->domain ).'</small></label></p>';
 
-          $_hashify_file_name = get_site_option( 'sm_hashify_file_name' );
+            $_hashify_file_name = get_site_option( 'sm_hashify_file_name' );
 
-          $inputs[] = '<p><input type="hidden" name="sm[hashify_file_name]" value="0" />';
-          $inputs[] = '<label for="sm_hashify_file_name"><input id="sm_hashify_file_name" type="checkbox" name="sm[hashify_file_name]" value="1" '. checked( '1', $_hashify_file_name, false ) .'/>'.__( 'Randomize the filename of newly uploaded media files.', ud_get_stateless_media()->domain ).'<small> '.__( '(May help to avoid unwanted GCS caching)', ud_get_stateless_media()->domain ).'</small></label></p>';
+            $inputs[] = '<p><input type="hidden" name="sm[hashify_file_name]" value="0" />';
+            $inputs[] = '<label for="sm_hashify_file_name"><input id="sm_hashify_file_name" type="checkbox" name="sm[hashify_file_name]" value="1" '. checked( '1', $_hashify_file_name, false ) .'/>'.__( 'Randomize the filename of newly uploaded media files.', ud_get_stateless_media()->domain ).'<small> '.__( '(May help to avoid unwanted GCS caching)', ud_get_stateless_media()->domain ).'</small></label></p>';
 
-          echo implode( "\n", (array)apply_filters( 'sm::network::settings::advanced', $inputs ) );
-          ?>
-        </div>
+            echo implode( "\n", (array)apply_filters( 'sm::network::settings::advanced', $inputs ) );
+            ?>
+          </div>
         <?php
       }
 
@@ -369,7 +376,7 @@ namespace wpCloud\StatelessMedia {
         // use bucketname for static hosting
         $inputs[] = '<input type="hidden" name="sm[static_host]" value="false" />';
         $inputs[] = '<label for="sm_static_host"><input id="sm_static_host" type="checkbox" name="sm[static_host]" value="true" '. checked( 'true', $this->get
-( 'sm.static_host' ), false ) .'/>'.__( 'Use bucketname as hostname.', ud_get_stateless_media()->domain ).'</label>';
+          ( 'sm.static_host' ), false ) .'/>'.__( 'Use bucketname as hostname.', ud_get_stateless_media()->domain ).'</label>';
 
         // body content rewrite
         $inputs[] = '<input type="hidden" name="sm[body_rewrite]" value="false" />';
@@ -448,9 +455,9 @@ namespace wpCloud\StatelessMedia {
 
           $kjsn_readonly = defined( 'WP_STATELESS_MEDIA_KEY_FILE_PATH' ) ? 'readonly="readonly"' : '';
           $inputs[] = '<div class="key_type"><label>'.__('Service Account JSON', ud_get_stateless_media()->domain).'</label>';
-            $inputs[] = '<div class="_key_type _sm_key_json">';
-              $inputs[] = '<textarea '.$kjsn_readonly.' id="sm_key_json" class="field regular-textarea sm_key_json" type="text" name="sm[key_json]" >'. esc_attr( $this->get( 'sm.key_json' ) ) .'</textarea>';
-            $inputs[] = '</div>';
+          $inputs[] = '<div class="_key_type _sm_key_json">';
+          $inputs[] = '<textarea '.$kjsn_readonly.' id="sm_key_json" class="field regular-textarea sm_key_json" type="text" name="sm[key_json]" >'. esc_attr( $this->get( 'sm.key_json' ) ) .'</textarea>';
+          $inputs[] = '</div>';
           $inputs[] = '</div>';
         }
 
@@ -481,7 +488,9 @@ namespace wpCloud\StatelessMedia {
           '<p class="sm-mode"><label for="sm_mode_backup"><input '.$mode_readonly. disabled( true, $network_mode != 'false', false ) .' id="sm_mode_backup" '. checked( 'backup', $_mode, false ) .' type="radio" name="sm[mode]" value="backup" />'.__( 'Backup', ud_get_stateless_media()->domain ).''
           . '<small class="description">'.__('Push media files to Google Storage but keep using local ones.', ud_get_stateless_media()->domain).'</small></label></p>',
           '<p class="sm-mode"><label for="sm_mode_cdn"><input '.$mode_readonly. disabled( true, $network_mode != 'false', false ) .' id="sm_mode_cdn" '. checked( 'cdn', $_mode, false ) .' type="radio" name="sm[mode]" value="cdn" />'.__( 'CDN', ud_get_stateless_media()->domain ).''
-          . '<small class="description">'.__('Push media files to Google Storage and use them directly from there.', ud_get_stateless_media()->domain).'</small></label></p>'
+          . '<small class="description">'.__('Push media files to Google Storage and use them directly from there.', ud_get_stateless_media()->domain).'</small></label></p>',
+          '<p class="sm-mode"><label for="sm_mode_cdn_only"><input id="sm_mode_cdn_only" '. checked( 'cdn_only', $_mode, false ) .' type="radio" name="sm[mode]" value="cdn_only" />'.__( 'CDN Only', ud_get_stateless_media()->domain ).''
+          . '<small class="description">'.__('Push media files to Google Storage <strong>only</strong> and use them directly from there.', ud_get_stateless_media()->domain).'</small></label></p>'
         );
 
         if( $network_mode != 'false' ) {


### PR DESCRIPTION
**Total:**
- [x] Add CDN only mode

**When CDN only mode enabled:**
- [x] Show links from the GCS in any case
- [x] Prevent any uploads if API is unavailable
- [x] Prevent any deletions if API is unavailable
- [x] Implement method to delete file without deleting it from the local upload folder
- [x] File should be deleted from the local `upload` folder after uploading to the GCS
- [x] Disable `WP-Stateless` sync function if CDN Only mode enabled