### PR TITLE
use official google api client instead of usabilitydynamics fork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "composer/installers": "~1.0",
     "usabilitydynamics/lib-settings": "0.2.3",
     "usabilitydynamics/lib-wp-bootstrap": "1.2.1",
-    "usabilitydynamics/google-api-php-client": "^2.0.0",
+    "google/apiclient": "^2.0",
     "ccampbell/chromephp": "^4.1"
   },
   "require-dev": {


### PR DESCRIPTION
I think someone closer to the code should weigh in on if this is safe or not.  It's a pretty major change.  I uploaded one photo successfully in my dev environment after making this change.

This PR does not include the vendor changes after running `composer update`.  I don't know if that is appropriate in this PR or if a composer update typically happens at some other point in the release process, and also wanted to be sure we were happy with the version specified in `composer.json` before polluting this changelog.

Closes #120 