### PR TITLE
Fix: Get real path from symlink

### DIFF
--- a/lib/classes/class-bootstrap.php
+++ b/lib/classes/class-bootstrap.php
@@ -470,7 +470,7 @@ namespace wpCloud\StatelessMedia {
           foreach (wp_get_active_network_plugins() as $path) {
             // Trying again using readlink in case it's a symlink file.
             // boot_file is already solved.
-            if ($this->boot_file == $path || $this->boot_file == readlink($path)) {
+            if ($this->boot_file == $path || (is_link($path) AND $this->boot_file == readlink($path))) {
               return true;
             }
           }


### PR DESCRIPTION
This will give out a warning if $path is not a symlink.

Example:
><b>Warning</b>:  readlink(): Invalid argument in <b>/www/app/plugins/wp-stateless/lib/classes/class-bootstrap.php</b> on line <b>473</b>

[Read about readlink() behavior](http://php.net/manual/en/function.readlink.php#91458).

I have solved it by checking if $path is a symlink.