### PR TITLE
Support for GOOGLE_APPLICATION_CREDENTIALS

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,5 +1,6 @@
 #### 2.1.0
 * NEW - Added support for <code>GOOGLE_APPLICATION_CREDENTIALS</code> environment variable.
+* Fixed read only for Service Account JSON if constant or environment variable is defined. 
 
 #### 2.0.0
 * NEW - Added stateless mode.

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,6 @@
+#### 2.1.0
+* NEW - Added support for <code>GOOGLE_APPLICATION_CREDENTIALS</code> environment variable.
+
 #### 2.0.0
 * NEW - Added stateless mode.
 * NEW - Dedicated settings panel.

--- a/lib/classes/class-settings.php
+++ b/lib/classes/class-settings.php
@@ -149,11 +149,12 @@ namespace wpCloud\StatelessMedia {
         /**
          * JSON key file path
          */
+        $google_app_key_file = getenv('GOOGLE_APPLICATION_CREDENTIALS', true) ?: getenv('GOOGLE_APPLICATION_CREDENTIALS');
 
         /* Use constant value for JSON key file path, if set. */
-        if( defined( 'WP_STATELESS_MEDIA_KEY_FILE_PATH' ) ) {
+        if (defined('WP_STATELESS_MEDIA_KEY_FILE_PATH') || $google_app_key_file !== false) {
           /* Maybe fix the path to p12 file. */
-          $key_file_path = WP_STATELESS_MEDIA_KEY_FILE_PATH;
+          $key_file_path = (defined('WP_STATELESS_MEDIA_KEY_FILE_PATH')) ? WP_STATELESS_MEDIA_KEY_FILE_PATH : $google_app_key_file;
 
           if( !empty( $key_file_path ) ) {
             $upload_dir = wp_upload_dir();

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,11 @@ Setting a setting via constants will prevent ability to make changes in control 
 * WP_STATELESS_MEDIA_MODE - Set to "disabled", "backup" or "cdn" to configure mode. 
 * WP_STATELESS_MEDIA_KEY_FILE_PATH - Absolute, or relative to web-root, path to JSON key file.
 
+### Available Environment Variables
+Setting a setting via environment variables will prevent ability to make changes in control panel.
+
+* GOOGLE_APPLICATION_CREDENTIALS - Absolute, or relative to web-root, path to JSON key file.
+
 ### Response Headers
 
 * x-goog-meta-object-id


### PR DESCRIPTION
See issue #123.

Some notes:
* To fix read only setting, I replaced `WP_STATELESS_MEDIA_JSON_KEY` with `WP_STATELESS_MEDIA_KEY_FILE_PATH`. I don't see the purpose of `WP_STATELESS_MEDIA_JSON_KEY` constant when `WP_STATELESS_MEDIA_KEY_FILE_PATH` already exists.
* `WP_STATELESS_MEDIA_JSON_KEY` have higher priority than `GOOGLE_APPLICATION_CREDENTIALS`.
* I added "Currently configured via an environment variable." to `private $strings` to make it easier to troubleshoot. Just to print "Currently configured via a constant" may confuse some people.
* I don't know if "environment variable" is the right terminology for this. Maybe have more specific like "Google application credentials" is better?
* I left a note about `GOOGLE_APPLICATION_CREDENTIALS` in the readme file. But I want to somehow inform about the use of it in GCS and it can be defined by using `putenv` or add it to the server environment. Not sure it's information overkill or in what format this should be presented (eg. in FAQ or as part of a Google Cloud Storage plugin migration instructions).
* Did update the changelog. I have putted the read only issue as a "fix".
* I have used the PSR2 coding standard, with 2 spaces indentation.

I have tested this with Wordpress 4.8.1 (multisite) and PHP 7.1.7 in Docker. I defined `GOOGLE_APPLICATION_CREDENTIALS` both with `putenv` and with Docker environment variable.

Let me know if you have any feedback.