### PR TITLE
Check if key file is readable

### DIFF
--- a/lib/classes/class-settings.php
+++ b/lib/classes/class-settings.php
@@ -190,7 +190,7 @@ namespace wpCloud\StatelessMedia {
                 break;
 
             }
-            if(file_exists($key_file_path)){
+            if(is_readable($key_file_path)) {
               $this->set( 'sm.key_json', file_get_contents($key_file_path) );
             }
           }


### PR DESCRIPTION
I think it's a good idea not just only check if the file exists, but also it's readable. [is_readable()](http://php.net/manual/en/function.is-readable.php) should check if the file exist in same way that file_exists() does.