### PR TITLE
Added 'Force SSL' option for Custom CDN Domains that is served behind services like CloudFlare

### DIFF
--- a/lib/classes/class-bootstrap.php
+++ b/lib/classes/class-bootstrap.php
@@ -284,11 +284,11 @@ namespace wpCloud\StatelessMedia {
         $sm = $sm?$sm: $this->get( 'sm');
         $image_host = 'https://storage.googleapis.com/';
         $custom_domain = $sm['custom_domain'];
-        $is_ssl = strpos($custom_domain, 'https://');
+        $is_ssl = $sm['force_ssl'] === "1";
         $custom_domain = str_replace('https://', '', $custom_domain);
         $custom_domain = str_replace('http://', '', $custom_domain);
         if ( $sm['bucket'] && $custom_domain == $sm['bucket']) {
-            $image_host = $is_ssl === 0 ? 'https://' : 'http://';  // bucketname will be host
+            $image_host = $is_ssl ? 'https://' : 'http://';  // bucketname will be host
         }
         return apply_filters( 'get_gs_host', $image_host . $sm['bucket'], $image_host, $sm['bucket'], $is_ssl );
       }
@@ -303,7 +303,8 @@ namespace wpCloud\StatelessMedia {
       public function wp_stateless_bucket_link($fileLink) {
         $bucketname = $this->get( 'sm.bucket' );
         if ( strpos($fileLink, $bucketname) > 8) {
-          $fileLink = 'http://' . substr($fileLink, strpos($fileLink, $bucketname));
+          $sm = $sm?$sm: $this->get( 'sm');
+          $fileLink = ($sm['force_ssl'] === '1' ? 'https://': 'http://') . substr($fileLink, strpos($fileLink, $bucketname));
         }
         return $fileLink;
       }
@@ -345,6 +346,7 @@ namespace wpCloud\StatelessMedia {
             'cache_control',
             'delete_remote',
             'custom_domain',
+            'force_ssl',
             'organize_media',
             'hashify_file_name'
         );

--- a/lib/classes/class-settings.php
+++ b/lib/classes/class-settings.php
@@ -30,6 +30,7 @@ namespace wpCloud\StatelessMedia {
           'cache_control'          => array('WP_STATELESS_MEDIA_CACHE_CONTROL', ''), 
           'delete_remote'          => array('WP_STATELESS_MEDIA_DELETE_REMOTE', 'true'), 
           'custom_domain'          => array('WP_STATELESS_MEDIA_CUSTOM_DOMAIN', ''), 
+          'force_ssl'              => array('', 'false'), 
           'organize_media'         => array('', 'true'), 
           'hashify_file_name'      => array('WP_STATELESS_MEDIA_HASH_FILENAME', 'true'), 
         );

--- a/static/scripts/wp-stateless.js
+++ b/static/scripts/wp-stateless.js
@@ -641,12 +641,13 @@ var wpStatelessApp = angular.module('wpStatelessApp', [])
 
   $scope.sm.generatePreviewUrl = function() {
     var host = 'https://storage.googleapis.com/';
-    var is_ssl = $scope.sm.custom_domain.indexOf('https://');
+    var is_ssl = $scope.sm.force_ssl === "1";
     var custom_domain = $scope.sm.custom_domain;
     custom_domain = custom_domain.replace('https://', '');
     custom_domain = custom_domain.replace('http://', '');
+    $scope.sm.custom_domain = custom_domain;
     if ( $scope.sm.bucket && custom_domain == $scope.sm.bucket) {
-      host = is_ssl === 0 ? 'https://' : 'http://';  // bucketname will be host
+      host = is_ssl ? 'https://' : 'http://';  // bucketname will be host
     }
     host += $scope.sm.bucket ? $scope.sm.bucket : '{bucket-name}';
     var rootdir = $scope.sm.root_dir ? $scope.sm.root_dir + '/' : '';

--- a/static/views/settings_interface.php
+++ b/static/views/settings_interface.php
@@ -179,8 +179,24 @@
                                     </p>
                                     <p class="description">
                                     <strong ng-bind="sm.showNotice('custom_domain')" ></strong> <br>
-                                    <?php printf(__( 'Replace the default GCS domain with your own custom domain. This will require you to <a href="%s" target="_blank">configure a CNAME</a>. Be advised that the bucket name and domain name must match exactly and HTTPS is not supported with a custom domain.', ud_get_stateless_media()->domain ), 'https://cloud.google.com/storage/docs/xml-api/reference-uris#cname'); ?>
+                                    <?php printf(__( 'Replace the default GCS domain with your own custom domain. This will require you to <a href="%s" target="_blank">configure a CNAME</a>. Be advised that the bucket name and domain name must match exactly and HTTPS is not supported with a custom domain unless it is routed via other CDN services like <a href="https://cloudflare.com" target="_blank">CloudFlare</a>.', ud_get_stateless_media()->domain ), 'https://cloud.google.com/storage/docs/xml-api/reference-uris#cname'); ?>
                                     </p>
+                                    
+                                    <h4><?php _e( 'Force SSL', ud_get_stateless_media()->domain ); ?></h4>
+                                    <p>
+                                        <select id="org_url_grp" name="sm[force_ssl]" ng-model="sm.force_ssl" ng-change="sm.generatePreviewUrl()" ng-disabled="sm.readonly.organize_media">
+                                            <?php if(is_network_admin()): ?>
+                                            <option value=""><?php _e( 'Don\'t override', ud_get_stateless_media()->domain ); ?></option>
+                                            <?php endif; ?>
+                                            <option value="1"><?php _e( 'Enable', ud_get_stateless_media()->domain ); ?></option>
+                                            <option value=""><?php _e( 'Disable', ud_get_stateless_media()->domain ); ?></option>
+                                        </select>
+                                    </p>
+                                    <p class="description">
+                                    <?php printf(__( 'This will force SSL (HTTPS) to be used on your custom CDN domain, which is not supported by GCS by default. You will need to routed the custom CDN domain via other services like CloudFlare to <a href="%s" target="_blank">inject the required SSL encryption layer</a> (available in their free plan). <br/>Note: To enforce SSL on items uploaded previously, you might need to use the features in the Sync tab to perform a resync.', ud_get_stateless_media()->domain ), 'https://www.cloudflare.com/ssl/'); ?>
+                                    </p>
+
+
                                     <hr>
 
                                     <?php if(!is_network_admin()): ?>

--- a/static/views/settings_interface.php
+++ b/static/views/settings_interface.php
@@ -193,7 +193,7 @@
                                         </select>
                                     </p>
                                     <p class="description">
-                                    <?php printf(__( 'This will force SSL (HTTPS) to be used on your custom CDN domain, which is not supported by GCS by default. You will need to routed the custom CDN domain via other services like CloudFlare to <a href="%s" target="_blank">inject the required SSL encryption layer</a> (available in their free plan). <br/>Note: To enforce SSL on items uploaded previously, you might need to use the features in the Sync tab to perform a resync.', ud_get_stateless_media()->domain ), 'https://www.cloudflare.com/ssl/'); ?>
+                                    <?php printf(__( 'This will force SSL (HTTPS) to be used on your custom CDN domain, which is not supported by GCS by default. You will need to routed the custom CDN domain via other services like CloudFlare to <a href="%s" target="_blank">inject the required SSL encryption layer</a> (available in their free plan). <br/><br/>Note: To enforce SSL on items uploaded previously, you might need to use the features in the Sync tab to perform a resync.', ud_get_stateless_media()->domain ), 'https://www.cloudflare.com/ssl/'); ?>
                                     </p>
 
 


### PR DESCRIPTION
Toggle 'Force SSL' on to enable HTTPS support (domain routed via CloudFlare)

![screen shot 2018-07-28 at 22 12 15](https://user-images.githubusercontent.com/179761/43357394-532cc878-92b3-11e8-9257-78ee8019e0b5.png)
![screen shot 2018-07-28 at 22 12 46](https://user-images.githubusercontent.com/179761/43357399-6217dd32-92b3-11e8-8eba-e140c6ed7d54.png)
