### PR TITLE
Rebuilt wp_calculate_image_srcset() to return correct images

### DIFF
--- a/lib/classes/class-bootstrap.php
+++ b/lib/classes/class-bootstrap.php
@@ -247,28 +247,36 @@ namespace wpCloud\StatelessMedia {
       
       /**
        * Rebuild srcset from gs_link.
-       * 
+       * Using calculations returned from WordPress wp_calculate_image_srcset()
        * 
        */
       public function wp_calculate_image_srcset($sources, $size_array, $image_src, $image_meta, $attachment_id){
-
-        if ( empty( $image_meta['gs_link'] ) ) {
+        if (empty($image_meta['gs_link'])) {
           $image_meta = wp_get_attachment_metadata($attachment_id);
         }
-
+  
         foreach ($sources as $width => &$image) {
-          if($width == $image_meta['width'] && isset( $image_meta['gs_link'] ) && $image_meta['gs_link'] ){
-            $image['url'] = $image_meta['gs_link'];
+          if (!isset($image_meta['gs_name']) || empty($image_meta['gs_name'])) {
+            continue;
           }
-          elseif(isset($image_meta['sizes']) && is_array($image_meta['sizes'])){
+    
+          // If srcset includes original image src, replace it
+          if (substr_compare($image['url'], $image_meta['gs_name'], -strlen($image_meta['gs_name'])) === 0) {
+            $image['url'] = $image_meta['gs_link'];
+          // Replace all sizes
+          } elseif (isset($image_meta['sizes']) && is_array($image_meta['sizes'])) {
             foreach ($image_meta['sizes'] as $key => $meta) {
-              if($width == $meta['width'] && isset($meta['gs_link']) && $meta['gs_link']){
+              if (!isset($meta['gs_name']) || empty($meta['gs_name'])) {
+                continue;
+              }
+        
+              if (substr_compare($image['url'], $meta['gs_name'], -strlen($meta['gs_name'])) === 0) {
                 $image['url'] = $meta['gs_link'];
               }
             }
           }
         }
-
+  
         return $sources;
       }
 


### PR DESCRIPTION
Current implementation has a bug where it can return the wrong srcset images. See issue #328 for more information.

This PR solves that issue by only using and working with `$sources` returned from WordPress itself since filter in `wp-stateless` running after filter in WordPress. 
I'm not very fond of checking strings like this fix does, but I find it the best possible solution for now since it take fully advantage of the logic that WordPress does to calculate correct srcset output and order. 
Please let me know if you have better ideas for this.

Another approach is to copy WordPress function `wp_calculate_image_srcset()` entirely and make proper adjustments to replace with `gs_link` but that should be more expensive in terms of performance.

Let me know what you think and please make adjustments as you like.