### PR TITLE
Resolving conflicts when using compatiblity with WP Smush 3.x and WP Statless

### DIFF
--- a/lib/classes/compatibility/wp-smush.php
+++ b/lib/classes/compatibility/wp-smush.php
@@ -43,7 +43,7 @@ namespace wpCloud\StatelessMedia {
              */
             public function add_media_wrapper($metadata, $attachment_id){
                 global $wpsmush_settings;
-                $auto_smush = $wpsmush_settings->settings['auto'];
+                $auto_smush = $wpsmush_settings->get('auto');
 
                 if( !$auto_smush || !wp_attachment_is_image( $attachment_id ) ||
                     !apply_filters( 'wp_smush_image', true, $attachment_id ) || 


### PR DESCRIPTION
Hi,

I just found error after updating WP Smush to 3.x. Compatibility doesn't work anymore and cause 500 server error during image upload. Why? They've changed visibility of settings field in settings class, now it is private, we can only get info from there using their getters. I made quick fix, now all works fine.

