### PR TITLE
Update error-notice.js

### DIFF
--- a/static/scripts/error-notice.js
+++ b/static/scripts/error-notice.js
@@ -32,7 +32,7 @@ jQuery( document ).ready( function ($) {
       return false;
     });
 
-    jQuery( '.ud-admin-notice' ).off( 'click', '.dismiss');
+    jQuery( '.stateless-admin-notice.ud-admin-notice' ).off( 'click', '.dismiss');
     jQuery( document ).on( 'click', '.stateless-admin-notice.ud-admin-notice .dismiss-warning', function(e){
       e.preventDefault();
 


### PR DESCRIPTION
Previously removed all event of ud admin notice instead of only stateless notice.
Now only removing the stateless events.