### PR TITLE
Fixes #397

### DIFF
--- a/lib/classes/class-bootstrap.php
+++ b/lib/classes/class-bootstrap.php
@@ -1092,6 +1092,10 @@ namespace wpCloud\StatelessMedia {
           $metadata = get_post_meta( $attachment_id, '_wp_attachment_metadata', true );
         }
 
+        if(empty($metadata)){
+          $metadata = [];
+        }
+
         if( is_array( $metadata ) && is_array( $sm_cloud ) && !empty( $sm_cloud[ 'fileLink' ] ) ) {
           $metadata[ 'gs_link' ] = apply_filters('wp_stateless_bucket_link', $sm_cloud[ 'fileLink' ]);
           $metadata[ 'gs_name' ] = isset( $sm_cloud[ 'name' ] ) ? $sm_cloud[ 'name' ] : false;


### PR DESCRIPTION
`if( is_array( $metadata ) && is_array( $sm_cloud ) && !empty( $sm_cloud[ 'fileLink' ] ) ) {` expects the post to have atleast an empty array of metadata. PDF files have sm_cloud data but doesn't have any metadata (such as ISO, focal length, shutter speed and what not).

This fix converts the missing metadata into an empty array as it should be.

The problem prevented PDF files from being deleted from the bucket.