### PR TITLE
v2.3.2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,12 @@
 == Changelog ==
+= 2.3.2 =
+* FIX - Fixed video file doesn't get deleted from the server in `Stateless` mode. GitHub issue [#418](https://github.com/wpCloud/wp-stateless/issues/418).
+* FIX - Fixed file size doesn't show under attachment details in `Stateless` mode. GitHub issue [#413](https://github.com/wpCloud/wp-stateless/issues/413).
+* FIX - Fixed Cache-Busting feature works even if the Mode is `Disabled`. GitHub issue [#405](https://github.com/wpCloud/wp-stateless/issues/405).
+* COMPATIBILITY - Fixed Gravity Form Post Image didn't include `Bucket Folder`. GitHub issue [#421](https://github.com/wpCloud/wp-stateless/issues/421).
+* COMPATIBILITY - Fixed Divi Builder Export. GitHub issue [#420](https://github.com/wpCloud/wp-stateless/issues/420).
+* COMPATIBILITY - Fixed BuddyBoss pages breaking after updating to 2.3.0. GitHub issue [#417](https://github.com/wpCloud/wp-stateless/issues/417).
+
 = 2.3.1 =
 * Fix - Fixed fatal error, undefined function `is_wp_version_compatible`. GitHub issue [#414](https://github.com/wpCloud/wp-stateless/issues/414).
 

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,11 @@
+#### 2.3.2 ####
+* FIX - Fixed video file doesn't get deleted from the server in `Stateless` mode. GitHub issue [#418](https://github.com/wpCloud/wp-stateless/issues/418).
+* FIX - Fixed file size doesn't show under attachment details in `Stateless` mode. GitHub issue [#413](https://github.com/wpCloud/wp-stateless/issues/413).
+* FIX - Fixed Cache-Busting feature works even if the Mode is `Disabled`. GitHub issue [#405](https://github.com/wpCloud/wp-stateless/issues/405).
+* COMPATIBILITY - Fixed Gravity Form Post Image didn't include `Bucket Folder`. GitHub issue [#421](https://github.com/wpCloud/wp-stateless/issues/421).
+* COMPATIBILITY - Fixed Divi Builder Export. GitHub issue [#420](https://github.com/wpCloud/wp-stateless/issues/420).
+* COMPATIBILITY - Fixed BuddyBoss pages breaking after updating to 2.3.0. GitHub issue [#417](https://github.com/wpCloud/wp-stateless/issues/417).
+
 #### 2.3.1 ####
 * Fix - Fixed fatal error, undefined function `is_wp_version_compatible`. GitHub issue [#414](https://github.com/wpCloud/wp-stateless/issues/414).
 

--- a/lib/classes/class-bootstrap.php
+++ b/lib/classes/class-bootstrap.php
@@ -25,7 +25,7 @@ namespace wpCloud\StatelessMedia {
        * @property $version
        * @type {Object}
        */
-      public static $version = '2.3.1';
+      public static $version = '2.3.2';
 
       /**
        * Singleton Instance Reference.

--- a/lib/classes/class-bootstrap.php
+++ b/lib/classes/class-bootstrap.php
@@ -141,27 +141,12 @@ namespace wpCloud\StatelessMedia {
         add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 
         /**
-         * Hashify file name if option is enabled
-         */
-        if ( $this->get( 'sm.hashify_file_name' ) == 'true' ) {
-          add_filter('sanitize_file_name', array( 'wpCloud\StatelessMedia\Utility', 'randomize_filename' ), 10);
-        }
-
-        /**
          * Delete table when blog is deleted.
          */
         add_action( 'wp_delete_site', array($this, 'wp_delete_site'));
 
         /* Initialize plugin only if Mode is not 'disabled'. */
         if ( $this->get( 'sm.mode' ) !== 'disabled' ) {
-
-          /**
-           * Override Cache Control is option is enabled
-           */
-          $cacheControl = trim($this->get( 'sm.cache_control' ));
-          if ( !empty($cacheControl) ) {
-            add_filter( 'sm:item:cacheControl', array( $this, 'override_cache_control' ) );
-          }
 
           /**
            * Determine if we have issues with connection to Google Storage Bucket
@@ -189,6 +174,21 @@ namespace wpCloud\StatelessMedia {
            * Carry on only if we do not have errors.
            */
           if( !$this->has_errors() ) {
+
+            /**
+             * Hashify file name if option is enabled
+             */
+            if ( $this->get( 'sm.hashify_file_name' ) == 'true' ) {
+              add_filter('sanitize_file_name', array( 'wpCloud\StatelessMedia\Utility', 'randomize_filename' ), 10);
+            }
+
+            /**
+             * Override Cache Control is option is enabled
+             */
+            $cacheControl = trim($this->get( 'sm.cache_control' ));
+            if ( !empty($cacheControl) ) {
+              add_filter( 'sm:item:cacheControl', array( $this, 'override_cache_control' ) );
+            }
 
             if( $this->get( 'sm.mode' ) === 'cdn' || $this->get( 'sm.mode' ) === 'stateless' ) {
               add_filter( 'wp_get_attachment_image_attributes', array( $this, 'wp_get_attachment_image_attributes' ), 20, 3 );

--- a/lib/classes/class-bootstrap.php
+++ b/lib/classes/class-bootstrap.php
@@ -624,6 +624,9 @@ namespace wpCloud\StatelessMedia {
         $upload_dir = wp_upload_dir();
         $current_path = str_replace( wp_normalize_path( trailingslashit( $upload_dir[ 'basedir' ] ) ), '', wp_normalize_path( $current_path ) );
         $current_path = str_replace( wp_normalize_path( trailingslashit( $upload_dir[ 'baseurl' ] ) ), '', wp_normalize_path( $current_path ) );
+        $current_path = str_replace( trailingslashit( $this->get_gs_host() ), '', $current_path );
+
+        $current_path = str_replace( trailingslashit( $root_dir ), '', $current_path );
 
         // skip adding root dir if it's already added.
         if ( $use_root && !empty( $root_dir ) && strpos($current_path, $root_dir) !== 0 ) {

--- a/lib/classes/class-compatibility.php
+++ b/lib/classes/class-compatibility.php
@@ -103,6 +103,11 @@ namespace wpCloud\StatelessMedia {
             new BuddyPress();
             
             /**
+             * Support for BuddyBoss
+             */
+            new BuddyBoss();
+            
+            /**
              * LiteSpeed Cache
              */
             new LSCacheWP();

--- a/lib/classes/class-utility.php
+++ b/lib/classes/class-utility.php
@@ -254,6 +254,19 @@ namespace wpCloud\StatelessMedia {
           ));
 
           /**
+           * Storing file size to sm_cloud first,
+           * Because assigning directly to $metadata['filesize'] don't work.
+           * Maybe filesize gets removed in first run (when file exists).
+           */
+          if ( file_exists( $fullsizepath ) ) {
+            $cloud_meta['filesize'] = filesize( $fullsizepath );
+          }
+          // Getting file size from sm_cloud.
+          if(!empty($cloud_meta['filesize'])){
+            $metadata['filesize'] = $cloud_meta['filesize'];
+          }
+          
+          /**
            * 
            */
           $image_sizes = self::get_path_and_url($metadata, $attachment_id);

--- a/lib/classes/class-utility.php
+++ b/lib/classes/class-utility.php
@@ -576,7 +576,12 @@ namespace wpCloud\StatelessMedia {
         ){
           // checks whether it's WP 5.3 and 'intermediate_image_sizes_advanced' is passed.
           // To be sure that we don't delete full size image before thumbnails are generated.
-          if(is_wp_version_compatible('5.3-RC4-46673') && !in_array($attachment_id, self::$can_delete_attachment)){
+          if(
+            wp_attachment_is_image($attachment_id) &&
+            function_exists('is_wp_version_compatible') && 
+            is_wp_version_compatible('5.3-RC4-46673') && 
+            !in_array($attachment_id, self::$can_delete_attachment)
+          ){
             return false;
           }
           return true;

--- a/lib/classes/compatibility/buddyboss.php
+++ b/lib/classes/compatibility/buddyboss.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Plugin Name: BuddyPress
+ * Plugin URI: https://www.buddyboss.com/platform/
+ *
+ * Compatibility Description: Ensures compatibility with BuddyBoss.
+ *
+ */
+
+namespace wpCloud\StatelessMedia {
+
+    if(!class_exists('wpCloud\StatelessMedia\BuddyBoss')) {
+        
+        class BuddyBoss extends ICompatibility {
+            protected $id = 'buddyboss';
+            protected $title = 'BuddyBoss';
+            protected $constant = 'WP_STATELESS_COMPATIBILITY_BUDDYPRESS';
+            protected $description = 'Ensures compatibility with BuddyBoss.';
+            protected $plugin_file = ['buddyboss-platform/bp-loader.php'];
+
+            public function module_init($sm){
+                add_filter( 'stateless_skip_cache_busting', array($this, 'skip_cache_busting'), 10, 2 );
+            }
+
+            /**
+             * skip cache busting for template file name.
+             */
+            public function skip_cache_busting($return, $filename){
+                $info = pathinfo($filename);
+                $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 8);
+                if(empty($info['extension']) && strpos($backtrace[6]['file'], '/buddyboss-platform/') !== false){
+                    return $filename;
+                }
+                return $return;
+            }
+
+        }
+
+    }
+
+}

--- a/lib/classes/compatibility/buddyboss.php
+++ b/lib/classes/compatibility/buddyboss.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: BuddyPress
+ * Plugin Name: BuddyBoss
  * Plugin URI: https://www.buddyboss.com/platform/
  *
  * Compatibility Description: Ensures compatibility with BuddyBoss.
@@ -14,7 +14,7 @@ namespace wpCloud\StatelessMedia {
         class BuddyBoss extends ICompatibility {
             protected $id = 'buddyboss';
             protected $title = 'BuddyBoss';
-            protected $constant = 'WP_STATELESS_COMPATIBILITY_BUDDYPRESS';
+            protected $constant = 'WP_STATELESS_COMPATIBILITY_BUDDYBOSS';
             protected $description = 'Ensures compatibility with BuddyBoss.';
             protected $plugin_file = ['buddyboss-platform/bp-loader.php'];
 

--- a/lib/classes/compatibility/buddypress.php
+++ b/lib/classes/compatibility/buddypress.php
@@ -21,12 +21,12 @@ namespace wpCloud\StatelessMedia {
             public function module_init($sm){
                 add_action('xprofile_avatar_uploaded', array($this, 'avatar_uploaded'), 10, 3);
                 add_action('groups_avatar_uploaded', array($this, 'avatar_uploaded'), 10, 3);
-
                 add_action('bp_core_fetch_avatar', array($this, 'bp_core_fetch_avatar'), 10, 3);
-                add_filter('bp_core_fetch_avatar_url', array($this, 'bp_core_fetch_avatar'), 10, 3);
-                // in stateless mode
-                add_filter('bp_core_pre_delete_existing_avatar', array($this, 'bp_core_fetch_avatar'), 10, 2);
-                // add_action('bp_core_delete_existing_avatar', array($this, 'delete_existing_avatar'));
+
+                add_filter('bp_core_fetch_avatar_url', array($this, 'bp_core_fetch_avatar_url'), 10, 3);
+                add_filter('bp_core_pre_delete_existing_avatar', array($this, 'delete_existing_avatar'), 10, 2);
+                add_filter('bp_attachments_pre_get_attachment', array($this, 'bp_attachments_pre_get_attachment'), 10, 2);
+
             }
 
             public function avatar_uploaded($item_id, $type, $r){
@@ -43,56 +43,101 @@ namespace wpCloud\StatelessMedia {
                     'type'    => 'thumb',
                 ) );
 
-                $bp_upload_path = bp_core_get_upload_dir('upload_path');
-                $full_avatar = trim(str_replace( bp_core_avatar_url(), '', $full_avatar ), '/');
-                $full_avatar_path = $bp_upload_path . '/' .  $full_avatar;
+                $wp_uploads_dir = wp_get_upload_dir();
 
-                $thumb_avatar = trim(str_replace( bp_core_avatar_url(), '', $thumb_avatar ), '/');
-                $thumb_avatar_path = $bp_upload_path . '/' .  $thumb_avatar;
 
-                do_action( 'sm:sync::syncFile', apply_filters( 'wp_stateless_file_name', $full_avatar), $full_avatar_path, true, array('stateless' => false));
-                do_action( 'sm:sync::syncFile', apply_filters( 'wp_stateless_file_name', $thumb_avatar), $thumb_avatar_path, true, array('stateless' => false));
+                $full_avatar_path = $wp_uploads_dir['basedir'] . '/' . apply_filters( 'wp_stateless_file_name', $full_avatar, false);
+                $full_avatar = apply_filters( 'wp_stateless_file_name', $full_avatar);
+
+                $thumb_avatar_path = $wp_uploads_dir['basedir'] . '/' . apply_filters( 'wp_stateless_file_name', $thumb_avatar, false);
+                $thumb_avatar = apply_filters( 'wp_stateless_file_name', $thumb_avatar);
+
+                do_action( 'sm:sync::syncFile', $full_avatar, $full_avatar_path, true, array('stateless' => false));
+                do_action( 'sm:sync::syncFile', $thumb_avatar, $thumb_avatar_path, true, array('stateless' => false));
 
             }
 
-            public function bp_core_fetch_avatar($url){
-                $url = ud_get_stateless_media()->the_content_filter($url);
-                // die();
+            /**
+             * Convert image url in image html to GCS URL.
+             *
+             * @param [type] $image_html html code for image.
+             * @return void
+             */
+            public function bp_core_fetch_avatar($image_html){
+                $image_html = ud_get_stateless_media()->the_content_filter($image_html);
+                return $image_html;
+            }
+
+            /**
+             * 
+             *
+             * @param [type] $url image url.
+             * @return void
+             */
+            public function bp_core_fetch_avatar_url($url){
+                $name = apply_filters( 'wp_stateless_file_name', $url);
+                $url = ud_get_stateless_media()->get_gs_host() . '/' . $name;
                 return $url;
             }
 
             public function delete_existing_avatar($return, $args){
-                // print_r(func_get_args());
                 if(empty($args['object']) && empty($args['item_id'])){
                     return $return;
                 }
 
-                $_full_avatar = bp_core_fetch_avatar( array(
+                $full_avatar = bp_core_fetch_avatar( array(
                     'object'  => $args['object'],
                     'item_id' => $args['item_id'],
                     'html'    => false,
                     'type'    => 'full',
                 ) );
-                $_thumb_avatar = bp_core_fetch_avatar( array(
+                $thumb_avatar = bp_core_fetch_avatar( array(
                     'object'  => $args['object'],
                     'item_id' => $args['item_id'],
                     'html'    => false,
                     'type'    => 'thumb',
                 ) );
 
-                $full_avatar = trim(str_replace( bp_core_avatar_url(), '', $_full_avatar ), '/');
-                $thumb_avatar = trim(str_replace( bp_core_avatar_url(), '', $_thumb_avatar ), '/');
-                if($full_avatar != $_full_avatar){
-                    do_action( 'sm:sync::deleteFile', apply_filters( 'wp_stateless_file_name', $full_avatar));
-                }
-                if($thumb_avatar != $_thumb_avatar){
-                    do_action( 'sm:sync::deleteFile', apply_filters( 'wp_stateless_file_name', $thumb_avatar));
+                do_action( 'sm:sync::deleteFile', apply_filters( 'wp_stateless_file_name', $full_avatar));
+                do_action( 'sm:sync::deleteFile', apply_filters( 'wp_stateless_file_name', $thumb_avatar));
+
+                if(ud_get_stateless_media()->get( 'sm.mode' ) === 'stateless'){
+                    $return = false;
                 }
 
-                // var_dump($_full_avatar);
-                // var_dump($full_avatar);
-                // var_dump($_thumb_avatar);
-                // var_dump($thumb_avatar);
+                return $return;
+            }
+
+            /**
+             * Sync and return GCS url for group images.
+             *
+             * @param [type] $return
+             * @param [type] $r
+             * @return void
+             */
+            public function bp_attachments_pre_get_attachment($return, $r){
+                if(!empty($r['recursive'])){
+                    return $return;
+                }
+
+                try {
+                    $debug_backtrace = \debug_backtrace(false);
+
+                    if(!empty($debug_backtrace[3]['args'][0]) && $debug_backtrace[3]['args'][0] == 'url'){
+                        $r['recursive'] = true;
+
+                        $url = bp_attachments_get_attachment('url', $r);
+                        $name = apply_filters( 'wp_stateless_file_name', $url);
+
+                        $full_path = bp_attachments_get_attachment(false, $r);
+                        do_action( 'sm:sync::syncFile', $name, $full_path, true, array('stateless' => false));
+
+                        $return = ud_get_stateless_media()->get_gs_host() . '/' . $name;
+                    }
+                } catch (\Throwable $th) {
+                    //throw $th;
+                }
+
 
                 return $return;
             }

--- a/lib/classes/compatibility/buddypress.php
+++ b/lib/classes/compatibility/buddypress.php
@@ -21,12 +21,12 @@ namespace wpCloud\StatelessMedia {
             public function module_init($sm){
                 add_action('xprofile_avatar_uploaded', array($this, 'avatar_uploaded'), 10, 3);
                 add_action('groups_avatar_uploaded', array($this, 'avatar_uploaded'), 10, 3);
+
                 add_action('bp_core_fetch_avatar', array($this, 'bp_core_fetch_avatar'), 10, 3);
-
-                add_filter('bp_core_fetch_avatar_url', array($this, 'bp_core_fetch_avatar_url'), 10, 3);
-                add_filter('bp_core_pre_delete_existing_avatar', array($this, 'delete_existing_avatar'), 10, 2);
-                add_filter('bp_attachments_pre_get_attachment', array($this, 'bp_attachments_pre_get_attachment'), 10, 2);
-
+                add_filter('bp_core_fetch_avatar_url', array($this, 'bp_core_fetch_avatar'), 10, 3);
+                // in stateless mode
+                add_filter('bp_core_pre_delete_existing_avatar', array($this, 'bp_core_fetch_avatar'), 10, 2);
+                // add_action('bp_core_delete_existing_avatar', array($this, 'delete_existing_avatar'));
             }
 
             public function avatar_uploaded($item_id, $type, $r){
@@ -43,101 +43,56 @@ namespace wpCloud\StatelessMedia {
                     'type'    => 'thumb',
                 ) );
 
-                $wp_uploads_dir = wp_get_upload_dir();
+                $bp_upload_path = bp_core_get_upload_dir('upload_path');
+                $full_avatar = trim(str_replace( bp_core_avatar_url(), '', $full_avatar ), '/');
+                $full_avatar_path = $bp_upload_path . '/' .  $full_avatar;
 
+                $thumb_avatar = trim(str_replace( bp_core_avatar_url(), '', $thumb_avatar ), '/');
+                $thumb_avatar_path = $bp_upload_path . '/' .  $thumb_avatar;
 
-                $full_avatar_path = $wp_uploads_dir['basedir'] . '/' . apply_filters( 'wp_stateless_file_name', $full_avatar, false);
-                $full_avatar = apply_filters( 'wp_stateless_file_name', $full_avatar);
-
-                $thumb_avatar_path = $wp_uploads_dir['basedir'] . '/' . apply_filters( 'wp_stateless_file_name', $thumb_avatar, false);
-                $thumb_avatar = apply_filters( 'wp_stateless_file_name', $thumb_avatar);
-
-                do_action( 'sm:sync::syncFile', $full_avatar, $full_avatar_path, true, array('stateless' => false));
-                do_action( 'sm:sync::syncFile', $thumb_avatar, $thumb_avatar_path, true, array('stateless' => false));
+                do_action( 'sm:sync::syncFile', apply_filters( 'wp_stateless_file_name', $full_avatar), $full_avatar_path, true, array('stateless' => false));
+                do_action( 'sm:sync::syncFile', apply_filters( 'wp_stateless_file_name', $thumb_avatar), $thumb_avatar_path, true, array('stateless' => false));
 
             }
 
-            /**
-             * Convert image url in image html to GCS URL.
-             *
-             * @param [type] $image_html html code for image.
-             * @return void
-             */
-            public function bp_core_fetch_avatar($image_html){
-                $image_html = ud_get_stateless_media()->the_content_filter($image_html);
-                return $image_html;
-            }
-
-            /**
-             * 
-             *
-             * @param [type] $url image url.
-             * @return void
-             */
-            public function bp_core_fetch_avatar_url($url){
-                $name = apply_filters( 'wp_stateless_file_name', $url);
-                $url = ud_get_stateless_media()->get_gs_host() . '/' . $name;
+            public function bp_core_fetch_avatar($url){
+                $url = ud_get_stateless_media()->the_content_filter($url);
+                // die();
                 return $url;
             }
 
             public function delete_existing_avatar($return, $args){
+                // print_r(func_get_args());
                 if(empty($args['object']) && empty($args['item_id'])){
                     return $return;
                 }
 
-                $full_avatar = bp_core_fetch_avatar( array(
+                $_full_avatar = bp_core_fetch_avatar( array(
                     'object'  => $args['object'],
                     'item_id' => $args['item_id'],
                     'html'    => false,
                     'type'    => 'full',
                 ) );
-                $thumb_avatar = bp_core_fetch_avatar( array(
+                $_thumb_avatar = bp_core_fetch_avatar( array(
                     'object'  => $args['object'],
                     'item_id' => $args['item_id'],
                     'html'    => false,
                     'type'    => 'thumb',
                 ) );
 
-                do_action( 'sm:sync::deleteFile', apply_filters( 'wp_stateless_file_name', $full_avatar));
-                do_action( 'sm:sync::deleteFile', apply_filters( 'wp_stateless_file_name', $thumb_avatar));
-
-                if(ud_get_stateless_media()->get( 'sm.mode' ) === 'stateless'){
-                    $return = false;
+                $full_avatar = trim(str_replace( bp_core_avatar_url(), '', $_full_avatar ), '/');
+                $thumb_avatar = trim(str_replace( bp_core_avatar_url(), '', $_thumb_avatar ), '/');
+                if($full_avatar != $_full_avatar){
+                    do_action( 'sm:sync::deleteFile', apply_filters( 'wp_stateless_file_name', $full_avatar));
+                }
+                if($thumb_avatar != $_thumb_avatar){
+                    do_action( 'sm:sync::deleteFile', apply_filters( 'wp_stateless_file_name', $thumb_avatar));
                 }
 
-                return $return;
-            }
-
-            /**
-             * Sync and return GCS url for group images.
-             *
-             * @param [type] $return
-             * @param [type] $r
-             * @return void
-             */
-            public function bp_attachments_pre_get_attachment($return, $r){
-                if(!empty($r['recursive'])){
-                    return $return;
-                }
-
-                try {
-                    $debug_backtrace = \debug_backtrace(false);
-
-                    if(!empty($debug_backtrace[3]['args'][0]) && $debug_backtrace[3]['args'][0] == 'url'){
-                        $r['recursive'] = true;
-
-                        $url = bp_attachments_get_attachment('url', $r);
-                        $name = apply_filters( 'wp_stateless_file_name', $url);
-
-                        $full_path = bp_attachments_get_attachment(false, $r);
-                        do_action( 'sm:sync::syncFile', $name, $full_path, true, array('stateless' => false));
-
-                        $return = ud_get_stateless_media()->get_gs_host() . '/' . $name;
-                    }
-                } catch (\Throwable $th) {
-                    //throw $th;
-                }
-
+                // var_dump($_full_avatar);
+                // var_dump($full_avatar);
+                // var_dump($_thumb_avatar);
+                // var_dump($thumb_avatar);
 
                 return $return;
             }

--- a/lib/classes/compatibility/divi.php
+++ b/lib/classes/compatibility/divi.php
@@ -20,8 +20,13 @@ namespace wpCloud\StatelessMedia {
             protected $theme_name = 'Divi';
 
             public function module_init($sm){
-                // exclude randomize_filename from wpforms page
-                if(wp_doing_ajax() && !empty($_POST['et_core_portability_export']) && $_POST['et_core_portability_export'] == 'et_core_portability_export') {
+                // exclude randomize_filename from export
+                if(
+                    !empty($_GET['et_core_portability']) ||
+                    wp_doing_ajax() && 
+                    (!empty($_POST['action']) && $_POST['action'] == 'et_core_portability_export') ||
+                    (!empty($_POST['et_core_portability_export']) && $_POST['et_core_portability_export'] == 'et_core_portability_export')
+                ) {
                     remove_filter( 'sanitize_file_name', array( "wpCloud\StatelessMedia\Utility", 'randomize_filename' ), 10 );
                 }
                 

--- a/lib/classes/compatibility/gravity-forms.php
+++ b/lib/classes/compatibility/gravity-forms.php
@@ -101,7 +101,7 @@ namespace wpCloud\StatelessMedia {
                         $name = apply_filters( 'wp_stateless_file_name', $name);
                         do_action( 'sm:sync::syncFile', $name, $absolutePath);
 
-                        $value = ud_get_stateless_media()->get_gs_host() . '/' . $_name;
+                        $value = ud_get_stateless_media()->get_gs_host() . '/' . $name;
                         // Todo add filter.
                         if(version_compare($this->plugin_version, '2.3', '<')){ // older version
                             $result = $wpdb->update( $lead_detail_table, array( 'value' => $value ), array( 'lead_id' => $lead_detail_id, 'form_id' => $form['id'], 'field_number' => $field['id'], ), array( '%s' ), array( '%d' ) );

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wp-stateless",
   "title": "WP-Stateless",
   "description": "wpCloud Stateless Media for GCE",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "homepage": "https://usabilitydynamics.com",
   "author": {
     "name": "UsabilityDynamics, Inc.",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.usabilitydynamics.com
 Tags: google, google cloud, google cloud storage, cdn, uploads, media, stateless, backup
 License: GPLv2 or later
 Requires PHP: 5.5
-Requires at least: 4.0
+Requires at least: 4.7.0
 Tested up to: 5.3
 Stable tag: 2.3.1
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ License: GPLv2 or later
 Requires PHP: 5.5
 Requires at least: 4.7.0
 Tested up to: 5.3
-Stable tag: 2.3.1
+Stable tag: 2.3.2.RC1
 
 Upload and serve your WordPress media files from Google Cloud Storage.
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ License: GPLv2 or later
 Requires PHP: 5.5
 Requires at least: 4.7.0
 Tested up to: 5.3
-Stable tag: 2.3.2.RC1
+Stable tag: 2.3.2
 
 Upload and serve your WordPress media files from Google Cloud Storage.
 
@@ -103,6 +103,14 @@ To ensure new releases cause as little disruption as possible, we rely on a numb
 Fixed fatal error, undefined function `is_wp_version_compatible`.
 
 == Changelog ==
+= 2.3.2 =
+* FIX - Fixed video file doesn't get deleted from the server in `Stateless` mode. GitHub issue [#418](https://github.com/wpCloud/wp-stateless/issues/418).
+* FIX - Fixed file size doesn't show under attachment details in `Stateless` mode. GitHub issue [#413](https://github.com/wpCloud/wp-stateless/issues/413).
+* FIX - Fixed Cache-Busting feature works even if the Mode is `Disabled`. GitHub issue [#405](https://github.com/wpCloud/wp-stateless/issues/405).
+* COMPATIBILITY - Fixed Gravity Form Post Image didn't include `Bucket Folder`. GitHub issue [#421](https://github.com/wpCloud/wp-stateless/issues/421).
+* COMPATIBILITY - Fixed Divi Builder Export. GitHub issue [#420](https://github.com/wpCloud/wp-stateless/issues/420).
+* COMPATIBILITY - Fixed BuddyBoss pages breaking after updating to 2.3.0. GitHub issue [#417](https://github.com/wpCloud/wp-stateless/issues/417).
+
 = 2.3.1 =
 * Fix - Fixed fatal error, undefined function `is_wp_version_compatible`. GitHub issue [#414](https://github.com/wpCloud/wp-stateless/issues/414).
 

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -36,6 +36,7 @@ return array(
     'wpCloud\\StatelessMedia\\API' => $baseDir . '/lib/classes/class-api.php',
     'wpCloud\\StatelessMedia\\Ajax' => $baseDir . '/lib/classes/class-ajax.php',
     'wpCloud\\StatelessMedia\\Bootstrap' => $baseDir . '/lib/classes/class-bootstrap.php',
+    'wpCloud\\StatelessMedia\\BuddyBoss' => $baseDir . '/lib/classes/compatibility/buddyboss.php',
     'wpCloud\\StatelessMedia\\BuddyPress' => $baseDir . '/lib/classes/compatibility/buddypress.php',
     'wpCloud\\StatelessMedia\\CompatibilityAcfImageCrop' => $baseDir . '/lib/classes/compatibility/acf-image-crop.php',
     'wpCloud\\StatelessMedia\\CompatibilityWooExtraProductOptions' => $baseDir . '/lib/classes/compatibility/woo-extra-product-options.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -61,6 +61,7 @@ class ComposerStaticInitc00cd3c666f8dfa818cb7edfd488ed20
         'wpCloud\\StatelessMedia\\API' => __DIR__ . '/../..' . '/lib/classes/class-api.php',
         'wpCloud\\StatelessMedia\\Ajax' => __DIR__ . '/../..' . '/lib/classes/class-ajax.php',
         'wpCloud\\StatelessMedia\\Bootstrap' => __DIR__ . '/../..' . '/lib/classes/class-bootstrap.php',
+        'wpCloud\\StatelessMedia\\BuddyBoss' => __DIR__ . '/../..' . '/lib/classes/compatibility/buddyboss.php',
         'wpCloud\\StatelessMedia\\BuddyPress' => __DIR__ . '/../..' . '/lib/classes/compatibility/buddypress.php',
         'wpCloud\\StatelessMedia\\CompatibilityAcfImageCrop' => __DIR__ . '/../..' . '/lib/classes/compatibility/acf-image-crop.php',
         'wpCloud\\StatelessMedia\\CompatibilityWooExtraProductOptions' => __DIR__ . '/../..' . '/lib/classes/compatibility/woo-extra-product-options.php',

--- a/wp-stateless-media.php
+++ b/wp-stateless-media.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://www.usabilitydynamics.com
  * Description: Upload and serve your WordPress media files from Google Cloud Storage.
  * Author: Usability Dynamics, Inc.
- * Version: 2.3.1
+ * Version: 2.3.2.RC1
  * Text Domain: stateless-media
  * Author URI: https://www.usabilitydynamics.com
  *

--- a/wp-stateless-media.php
+++ b/wp-stateless-media.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://www.usabilitydynamics.com
  * Description: Upload and serve your WordPress media files from Google Cloud Storage.
  * Author: Usability Dynamics, Inc.
- * Version: 2.3.2.RC1
+ * Version: 2.3.2
  * Text Domain: stateless-media
  * Author URI: https://www.usabilitydynamics.com
  *


### PR DESCRIPTION
- FIX - Fixed video file doesn't get deleted from the server in `Stateless` mode. GitHub issue [#418](https://github.com/wpCloud/wp-stateless/issues/418).
- FIX - Fixed file size doesn't show under attachment details in `Stateless` mode. GitHub issue [#413](https://github.com/wpCloud/wp-stateless/issues/413).
- FIX - Fixed Cache-Busting feature works even if the Mode is `Disabled`. GitHub issue [#405](https://github.com/wpCloud/wp-stateless/issues/405).
- COMPATIBILITY - Fixed Gravity Form Post Image didn't include `Bucket Folder`. GitHub issue [#421](https://github.com/wpCloud/wp-stateless/issues/421).
- COMPATIBILITY  - Fixed Divi Builder Export. GitHub issue [#420](https://github.com/wpCloud/wp-stateless/issues/420).
- COMPATIBILITY - Fixed BuddyBoss pages breaking after updating to 2.3.0. GitHub issue [#417](https://github.com/wpCloud/wp-stateless/issues/417).