### PR TITLE
fix: add support for The Events Calendar

### DIFF
--- a/lib/classes/class-compatibility.php
+++ b/lib/classes/class-compatibility.php
@@ -33,6 +33,11 @@ namespace wpCloud\StatelessMedia {
       new BuddyBoss();
 
       /**
+       * Support for The Events Calendar
+       */
+      new TheEventsCalendar();
+
+      /**
        * Support for BuddyPress
        */
       new BuddyPress();

--- a/lib/classes/compatibility/the-events-calendar.php
+++ b/lib/classes/compatibility/the-events-calendar.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Plugin Name: TheEventsCalendar
+ * Plugin URI: https://wordpress.org/plugins/the-events-calendar/
+ *
+ * Compatibility Description: Ensures compatibility with The Events Calendar.
+ * Noteably: The Events Calendar does not store media, but it uses a fake file called 'silence'
+ *
+ */
+
+namespace wpCloud\StatelessMedia {
+
+  if( !class_exists( 'wpCloud\StatelessMedia\TheEventsCalendar' ) ) {
+
+    class TheEventsCalendar extends ICompatibility {
+      protected $id = 'theeventscalendar';
+      protected $title = 'TheEventsCalendar';
+      protected $constant = 'WP_STATELESS_COMPATIBILITY_THEEVENTSCALENDAR';
+      protected $description = 'Ensures compatibility with TheEventsCalendar.';
+      protected $plugin_file = [ 'the-events-calendar/the-events-calendar.php' ];
+      protected $sm_mode_not_supported = [ ];
+
+      /**
+       * @param $sm
+       */
+      public function module_init( $sm ) {
+        add_action( 'stateless_skip_cache_busting', array( $this, 'skip_cache_busting' ), 10, 2 );
+      }
+
+      /**
+       * skip cache busting for template file name.
+       * @param $return
+       * @param $filename
+       * @return mixed
+       */
+      public function skip_cache_busting( $return, $filename ) {
+        $backtrace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 8 );
+        if( strpos( $backtrace[ 7 ][ 'file' ], '/the-events-calendar/' ) !== false ) {
+          return $filename;
+        }
+        return $return;
+      }
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
[The Events Calendar](https://wordpress.org/plugins/the-events-calendar/)
does not use local media files. However, it was looking for a filename
'silence' which was confused by the cache-buster.