### PR TITLE
Ensure it's not installed with Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "udx/lib-ud-api-client": "~1.2",
     "ccampbell/chromephp": "^4.1",
     "firebase/php-jwt": "^5.2",
-    "wpmetabox/meta-box": "5.2.3"
+    "wpmetabox/meta-box": "5.2.3",
+    "guzzlehttp/guzzle": "~5.3.1||~6.0"
   },
   "autoload": {
     "classmap": [


### PR DESCRIPTION
The plugin didn't declare a dependency on a particular version of Guzzle, however if it's installed together with a package that installs Guzzle 7, it will completely break functionality because of a fatal error. Alternatively the code using Guzzle can probably be written tosupport all versions, but I didn't look into that further.

In any case something needs to be changed as currently it's very easy to miss this issue, it only manifests itself when you try to upload an image.