### PR TITLE
Removed deprecated and useless default value in PHP8.

### DIFF
--- a/lib/classes/class-bootstrap.php
+++ b/lib/classes/class-bootstrap.php
@@ -1317,7 +1317,7 @@ namespace wpCloud\StatelessMedia {
        * @param string $size
        * @return mixed $false
        */
-      public function image_downsize($false = false, $id, $size) {
+      public function image_downsize($false, $id, $size) {
 
         if ((!isset($this->client) || !$this->client || is_wp_error($this->client)) && $this->get('sm.mode') !== 'stateless') {
           return $false;


### PR DESCRIPTION
In PHP 8, E_DEPRECATED will occur if a function has an argument with a default value followed by a required argument.
Also, if the function is executed with apply_filter, it is not necessary to specify a default value.

This PR fixes #619.