### PR TITLE
Add WP_STATELESS_SKIP_ACL_SET for skip ACL set for GCS

### DIFF
--- a/lib/classes/class-gs-client.php
+++ b/lib/classes/class-gs-client.php
@@ -256,14 +256,14 @@ namespace wpCloud\StatelessMedia {
               'mimeType' => $args['mimeType'],
             );
 
-            if (defined('WP_STATELESS_SKIP_ACL_SET') && !WP_STATELESS_SKIP_ACL_SET) {
+            if ( !defined('WP_STATELESS_SKIP_ACL_SET') || !WP_STATELESS_SKIP_ACL_SET) {
               $mediaOptions['predefinedAcl'] = 'bucketOwnerFullControl';
             }
 
             $media = $this->service->objects->insert($this->bucket, $media, array_filter($mediaOptions));
           }
 
-          if (defined('WP_STATELESS_SKIP_ACL_SET') && !WP_STATELESS_SKIP_ACL_SET) {
+          if ( !defined('WP_STATELESS_SKIP_ACL_SET') || !WP_STATELESS_SKIP_ACL_SET) {
             $this->mediaInsertACL($name, $media, $args);
           }
         } catch (Exception $e) {

--- a/lib/classes/class-gs-client.php
+++ b/lib/classes/class-gs-client.php
@@ -250,15 +250,22 @@ namespace wpCloud\StatelessMedia {
             // Reset to the client to execute requests immediately in the future.
             $this->client->setDefer(false);
           } else {
-            $media = $this->service->objects->insert($this->bucket, $media, array_filter(array(
+            $mediaOptions = array(
               'data' => file_get_contents($args['absolutePath']),
               'uploadType' => 'media',
               'mimeType' => $args['mimeType'],
-              'predefinedAcl' => 'bucketOwnerFullControl',
-            )));
+            );
+
+            if (defined('WP_STATELESS_SKIP_ACL_SET') && !WP_STATELESS_SKIP_ACL_SET) {
+              $mediaOptions['predefinedAcl'] = 'bucketOwnerFullControl';
+            }
+
+            $media = $this->service->objects->insert($this->bucket, $media, array_filter($mediaOptions));
           }
 
-          $this->mediaInsertACL($name, $media, $args);
+          if (defined('WP_STATELESS_SKIP_ACL_SET') && !WP_STATELESS_SKIP_ACL_SET) {
+            $this->mediaInsertACL($name, $media, $args);
+          }
         } catch (Exception $e) {
           return new WP_Error('sm_error', $e->getMessage());
         }


### PR DESCRIPTION
Hi there,

currently this plugin fails when GCS bucket created with [uniform bucket-level access](https://cloud.google.com/storage/docs/uniform-bucket-level-access), that not support ACL. So plugin cannot insert legacy ACL for an object when uniform bucket-level access is enabled.

This PR add `WP_STATELESS_SKIP_ACL_SET` constant, that fix it.

Solve #521