### PR TITLE
3.2.5

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,8 @@
 == Changelog ==
+= 3.2.5 =
+* FIX - Folder setting does not allow custom structure [#608](https://github.com/udx/wp-stateless/issues/608).
+* FIX - Stateless mode Incompatible with Inline Uploader [#675](https://github.com/udx/wp-stateless/issues/675).
+
 = 3.2.4 =
 * FIX - Website unresponsive after Upgrade [#669](https://github.com/udx/wp-stateless/issues/669).
 
@@ -26,7 +30,7 @@
 * FIX - Fixed vulnerability issues.
 * FIX - Fixed erros and warnings on PHP 8.
 * FIX - problem after the upgrade [#628](https://github.com/udx/wp-stateless/issues/628).
-* FIX - image_downsize() PHP8 Required parameter $id follows optional parameter $false [#619](https://github.com/udx/wp-stateless/issues/619). 
+* FIX - image_downsize() PHP8 Required parameter $id follows optional parameter $false [#619](https://github.com/udx/wp-stateless/issues/619).
 
 = 3.1.1 =
 * ENHANCEMENT - Notification for the administrator about finished synchronization. GitHub issue [#576](https://github.com/udx/wp-stateless/issues/576).
@@ -185,11 +189,11 @@
 * FIX - Resolved Google SDK conflict.
 * FIX - ICompatibility.php errors notice.
 * FIX - Undefined index: gs_link in class-bootstrap.php.
-* FIX - Media files with accent characters would not upload correctly to the bucket. 
-* ENHANCEMENT - Force `Cache-Busting` when using `Stateless` mode. 
+* FIX - Media files with accent characters would not upload correctly to the bucket.
+* ENHANCEMENT - Force `Cache-Busting` when using `Stateless` mode.
 * ENHANCEMENT - New admin notice design.
-* ENHANCEMENT - Improved and clear error message. 
-* ENHANCEMENT - Renamed constant `WP_STATELESS_MEDIA_ON_FLY` to `WP_STATELESS_DYNAMIC_IMAGE_SUPPORT`. 
+* ENHANCEMENT - Improved and clear error message.
+* ENHANCEMENT - Renamed constant `WP_STATELESS_MEDIA_ON_FLY` to `WP_STATELESS_DYNAMIC_IMAGE_SUPPORT`.
 * ENHANCEMENT - Update Google Libraries.
 * ENHANCEMENT - Renamed constant `WP_STATELESS_MEDIA_HASH_FILENAME` to `WP_STATELESS_MEDIA_CACHE_BUSTING`.
 * COMPATIBILITY - Renamed constant `WP_STATELESS_COMPATIBILITY_WPSmush` to `WP_STATELESS_COMPATIBILITY_WPSMUSH`.
@@ -239,7 +243,7 @@
 * COMPATIBILITY - Advanced Custom Fields Image Crop Addon.
 
 = 2.1.0 =
-* FIX - Fixed read only for Service Account JSON if constant or environment variable is defined. 
+* FIX - Fixed read only for Service Account JSON if constant or environment variable is defined.
 * FIX - Override default cache control.
 * FIX - Fixed custom domain bucket support with setup assistant.
 * FIX - Improved support for wp_calculate_image_srcset.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 = 3.2.5 =
 * FIX - Folder setting does not allow custom structure [#608](https://github.com/udx/wp-stateless/issues/608).
 * FIX - Stateless mode Incompatible with Inline Uploader [#675](https://github.com/udx/wp-stateless/issues/675).
+* FIX - html tags incorrectly applied in notice [#680](https://github.com/udx/wp-stateless/issues/680).
 * ENHANCEMENT - Add WP_STATELESS_SKIP_ACL_SET for skip ACL set for GCS [#625](https://github.com/udx/wp-stateless/issues/625).
 * COMPATIBILITY - Add support for The Events Calendar [#599](https://github.com/udx/wp-stateless/issues/599).
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,8 @@
 = 3.2.5 =
 * FIX - Folder setting does not allow custom structure [#608](https://github.com/udx/wp-stateless/issues/608).
 * FIX - Stateless mode Incompatible with Inline Uploader [#675](https://github.com/udx/wp-stateless/issues/675).
+* ENHANCEMENT - Add WP_STATELESS_SKIP_ACL_SET for skip ACL set for GCS [#625](https://github.com/udx/wp-stateless/issues/625).
+* COMPATIBILITY - Add support for The Events Calendar [#599](https://github.com/udx/wp-stateless/issues/599).
 
 = 3.2.4 =
 * FIX - Website unresponsive after Upgrade [#669](https://github.com/udx/wp-stateless/issues/669).

--- a/changes.md
+++ b/changes.md
@@ -1,6 +1,7 @@
 #### 3.2.5
 * FIX - Folder setting does not allow custom structure [#608](https://github.com/udx/wp-stateless/issues/608).
 * FIX - Stateless mode Incompatible with Inline Uploader [#675](https://github.com/udx/wp-stateless/issues/675).
+* FIX - html tags incorrectly applied in notice [#680](https://github.com/udx/wp-stateless/issues/680).
 * ENHANCEMENT - Add WP_STATELESS_SKIP_ACL_SET for skip ACL set for GCS [#625](https://github.com/udx/wp-stateless/issues/625).
 * COMPATIBILITY - Add support for The Events Calendar [#599](https://github.com/udx/wp-stateless/issues/599).
 

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,7 @@
+#### 3.2.5
+* FIX - Folder setting does not allow custom structure [#608](https://github.com/udx/wp-stateless/issues/608).
+* FIX - Stateless mode Incompatible with Inline Uploader [#675](https://github.com/udx/wp-stateless/issues/675).
+
 #### 3.2.4
 
 - FIX - Website unresponsive after Upgrade [#669](https://github.com/udx/wp-stateless/issues/669).
@@ -30,7 +34,7 @@
 - FIX - Fixed vulnerability issues.
 - FIX - Fixed erros and warnings on PHP 8.
 - FIX - problem after the upgrade [#628](https://github.com/udx/wp-stateless/issues/628).
-- FIX - image_downsize() PHP8 Required parameter $id follows optional parameter $false [#619](https://github.com/udx/wp-stateless/issues/619). 
+- FIX - image_downsize() PHP8 Required parameter $id follows optional parameter $false [#619](https://github.com/udx/wp-stateless/issues/619).
 
 #### 3.1.1
 

--- a/changes.md
+++ b/changes.md
@@ -1,6 +1,8 @@
 #### 3.2.5
 * FIX - Folder setting does not allow custom structure [#608](https://github.com/udx/wp-stateless/issues/608).
 * FIX - Stateless mode Incompatible with Inline Uploader [#675](https://github.com/udx/wp-stateless/issues/675).
+* ENHANCEMENT - Add WP_STATELESS_SKIP_ACL_SET for skip ACL set for GCS [#625](https://github.com/udx/wp-stateless/issues/625).
+* COMPATIBILITY - Add support for The Events Calendar [#599](https://github.com/udx/wp-stateless/issues/599).
 
 #### 3.2.4
 

--- a/lib/classes/class-bootstrap.php
+++ b/lib/classes/class-bootstrap.php
@@ -18,6 +18,8 @@ namespace wpCloud\StatelessMedia {
 
     final class Bootstrap extends \UsabilityDynamics\WP\Bootstrap_Plugin {
 
+      const REQUIRED_PHP_VERSION = '8.0';
+
       /**
        * Google Storage Client
        * Use $this->get_client()
@@ -156,8 +158,8 @@ namespace wpCloud\StatelessMedia {
         /**
          * To prevent fatal errors for users who use PHP 5.5 or less.
          */
-        if (version_compare(PHP_VERSION, '5.5', '<')) {
-          $this->errors->add(sprintf(__('The plugin requires PHP %s or higher. You current PHP version %s is too old.', ud_get_stateless_media()->domain), '<b>5.5</b>', '<b>' . PHP_VERSION . '</b>'));
+        if (version_compare(PHP_VERSION, self::REQUIRED_PHP_VERSION, '<')) {
+          $this->errors->add(sprintf(__('The plugin requires PHP %s or higher. You current PHP version %s is too old.', ud_get_stateless_media()->domain), '<b>' . self::REQUIRED_PHP_VERSION . '</b>', '<b>' . PHP_VERSION . '</b>'));
         }
 
         /**

--- a/lib/classes/class-bootstrap.php
+++ b/lib/classes/class-bootstrap.php
@@ -18,7 +18,7 @@ namespace wpCloud\StatelessMedia {
 
     final class Bootstrap extends \UsabilityDynamics\WP\Bootstrap_Plugin {
 
-      const REQUIRED_PHP_VERSION = '8.0';
+      const REQUIRED_PHP_VERSION = '5.5';
 
       /**
        * Google Storage Client

--- a/lib/classes/class-bootstrap.php
+++ b/lib/classes/class-bootstrap.php
@@ -1548,7 +1548,7 @@ namespace wpCloud\StatelessMedia {
             $connected = $client->is_connected();
             if ($connected !== true) {
               $trnst['success'] = 'false';
-              $trnst['error'] = sprintf(__('Could not connect to Google Storage bucket. Please, be sure that bucket with name <b>%s</b> exists.', $this->domain), esc_html($this->get('sm.bucket')));
+              $trnst['error'] = sprintf(__('Could not connect to Google Storage bucket. Please be sure that bucket with name <b>%s</b> exists.', $this->domain), esc_html($this->get('sm.bucket')));
 
               if (is_callable(array($connected, 'getHandlerContext')) && $handlerContext = $connected->getHandlerContext()) {
                 if (!empty($handlerContext['error'])) {

--- a/lib/classes/class-bootstrap.php
+++ b/lib/classes/class-bootstrap.php
@@ -213,6 +213,13 @@ namespace wpCloud\StatelessMedia {
               }
             }
 
+            if ($sm_mode === 'stateless') {
+              /**
+               * Replacing local path to gs:// for using it on StreamWrapper
+               */
+              add_filter('upload_dir', array($this, 'filter_upload_dir'), 99);
+            }
+
             if ($this->get('sm.delete_remote') == 'true') {
               /**
                * On physical file deletion we remove any from GS
@@ -1264,8 +1271,8 @@ namespace wpCloud\StatelessMedia {
               'key' => 'stateless-cache-busting',
               'class' => 'notice',
               'title' => sprintf(__("Stateless and Ephemeral modes enables and requires the Cache-Busting option.", ud_get_stateless_media()->domain)),
-              'message' => sprintf(__("WordPress looks at local files to prevent files with the same filenames. 
-                                          Since Stateless mode bypasses this check, there is a potential for files to be stored with the same file name. We enforce the Cache-Busting option to prevent this. 
+              'message' => sprintf(__("WordPress looks at local files to prevent files with the same filenames.
+                                          Since Stateless mode bypasses this check, there is a potential for files to be stored with the same file name. We enforce the Cache-Busting option to prevent this.
                                           Override with the <a href='%s' target='_blank'>%s</a> constant.", ud_get_stateless_media()->domain), "https://wp-stateless.github.io/docs/constants/#wp_stateless_media_cache_busting", "WP_STATELESS_MEDIA_CACHE_BUSTING"),
             );
             echo "<script id='template-stateless-cache-busting' type='text/html'>";
@@ -1713,8 +1720,8 @@ namespace wpCloud\StatelessMedia {
           'button' => 'View Settings',
           'button_link' => admin_url('upload.php?page=stateless-settings'),
           'title' => sprintf(__("Stateless mode now requires the Cache-Busting option.", ud_get_stateless_media()->domain)),
-          'message' => sprintf(__("WordPress looks at local files to prevent files with the same filenames. 
-                                Since Stateless mode bypasses this check, there is a potential for files to be stored with the same file name. We enforce the Cache-Busting option to prevent this. 
+          'message' => sprintf(__("WordPress looks at local files to prevent files with the same filenames.
+                                Since Stateless mode bypasses this check, there is a potential for files to be stored with the same file name. We enforce the Cache-Busting option to prevent this.
                                 Override with the <a href='%s' target='_blank'>%s</a> constant.", ud_get_stateless_media()->domain), "https://wp-stateless.github.io/docs/constants/#wp_stateless_media_cache_busting", "WP_STATELESS_MEDIA_CACHE_BUSTING"),
         ), 'notice');
       }

--- a/lib/classes/class-compatibility.php
+++ b/lib/classes/class-compatibility.php
@@ -33,6 +33,11 @@ namespace wpCloud\StatelessMedia {
       new BuddyBoss();
 
       /**
+       * Support for The Events Calendar
+       */
+      new TheEventsCalendar();
+
+      /**
        * Support for BuddyPress
        */
       new BuddyPress();

--- a/lib/classes/class-errors.php
+++ b/lib/classes/class-errors.php
@@ -106,7 +106,7 @@ namespace wpCloud\StatelessMedia {
           case 'notice':
             if(!is_array($message)){
               $message = array( 
-                'title' => sprintf( __( '<b>%s</b> has the following notice:', $this->domain ), esc_html($this->name) ),
+                'title' => sprintf( __( '%s has the following notice:', $this->domain ), esc_html($this->name) ),
                 'message' => $message,
                 'button' => null,
               );

--- a/lib/classes/class-gs-client.php
+++ b/lib/classes/class-gs-client.php
@@ -256,14 +256,14 @@ namespace wpCloud\StatelessMedia {
               'mimeType' => $args['mimeType'],
             );
 
-            if (defined('WP_STATELESS_SKIP_ACL_SET') && !WP_STATELESS_SKIP_ACL_SET) {
+            if ( !defined('WP_STATELESS_SKIP_ACL_SET') || !WP_STATELESS_SKIP_ACL_SET) {
               $mediaOptions['predefinedAcl'] = 'bucketOwnerFullControl';
             }
 
             $media = $this->service->objects->insert($this->bucket, $media, array_filter($mediaOptions));
           }
 
-          if (defined('WP_STATELESS_SKIP_ACL_SET') && !WP_STATELESS_SKIP_ACL_SET) {
+          if ( !defined('WP_STATELESS_SKIP_ACL_SET') || !WP_STATELESS_SKIP_ACL_SET) {
             $this->mediaInsertACL($name, $media, $args);
           }
         } catch (Exception $e) {

--- a/lib/classes/class-gs-client.php
+++ b/lib/classes/class-gs-client.php
@@ -250,15 +250,22 @@ namespace wpCloud\StatelessMedia {
             // Reset to the client to execute requests immediately in the future.
             $this->client->setDefer(false);
           } else {
-            $media = $this->service->objects->insert($this->bucket, $media, array_filter(array(
+            $mediaOptions = array(
               'data' => file_get_contents($args['absolutePath']),
               'uploadType' => 'media',
               'mimeType' => $args['mimeType'],
-              'predefinedAcl' => 'bucketOwnerFullControl',
-            )));
+            );
+
+            if (defined('WP_STATELESS_SKIP_ACL_SET') && !WP_STATELESS_SKIP_ACL_SET) {
+              $mediaOptions['predefinedAcl'] = 'bucketOwnerFullControl';
+            }
+
+            $media = $this->service->objects->insert($this->bucket, $media, array_filter($mediaOptions));
           }
 
-          $this->mediaInsertACL($name, $media, $args);
+          if (defined('WP_STATELESS_SKIP_ACL_SET') && !WP_STATELESS_SKIP_ACL_SET) {
+            $this->mediaInsertACL($name, $media, $args);
+          }
         } catch (Exception $e) {
           return new WP_Error('sm_error', $e->getMessage());
         }

--- a/lib/classes/class-settings.php
+++ b/lib/classes/class-settings.php
@@ -487,7 +487,7 @@ namespace wpCloud\StatelessMedia {
          * merging user's wildcards with default values
          */
         if (!empty($root_dir_values)) {
-          $wildcards = array_unique( array_merge($root_dir_values, $wildcards) );
+          $wildcards = array_unique( array_merge($root_dir_values, array_keys($wildcards)) );
         }
 
         include $this->bootstrap->path( '/static/views/settings_interface.php', 'dir' );

--- a/lib/classes/class-settings.php
+++ b/lib/classes/class-settings.php
@@ -487,7 +487,7 @@ namespace wpCloud\StatelessMedia {
          * merging user's wildcards with default values
          */
         if (!empty($root_dir_values)) {
-          $wildcards = array_merge(array_flip($root_dir_values), $wildcards);
+          $wildcards = array_unique( array_merge($root_dir_values, $wildcards) );
         }
 
         include $this->bootstrap->path( '/static/views/settings_interface.php', 'dir' );

--- a/lib/classes/compatibility/the-events-calendar.php
+++ b/lib/classes/compatibility/the-events-calendar.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Plugin Name: TheEventsCalendar
+ * Plugin URI: https://wordpress.org/plugins/the-events-calendar/
+ *
+ * Compatibility Description: Ensures compatibility with The Events Calendar.
+ * Noteably: The Events Calendar does not store media, but it uses a fake file called 'silence'
+ *
+ */
+
+namespace wpCloud\StatelessMedia {
+
+  if( !class_exists( 'wpCloud\StatelessMedia\TheEventsCalendar' ) ) {
+
+    class TheEventsCalendar extends ICompatibility {
+      protected $id = 'theeventscalendar';
+      protected $title = 'TheEventsCalendar';
+      protected $constant = 'WP_STATELESS_COMPATIBILITY_THEEVENTSCALENDAR';
+      protected $description = 'Ensures compatibility with TheEventsCalendar.';
+      protected $plugin_file = [ 'the-events-calendar/the-events-calendar.php' ];
+      protected $sm_mode_not_supported = [ ];
+
+      /**
+       * @param $sm
+       */
+      public function module_init( $sm ) {
+        add_action( 'stateless_skip_cache_busting', array( $this, 'skip_cache_busting' ), 10, 2 );
+      }
+
+      /**
+       * skip cache busting for template file name.
+       * @param $return
+       * @param $filename
+       * @return mixed
+       */
+      public function skip_cache_busting( $return, $filename ) {
+        $backtrace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 8 );
+        if( strpos( $backtrace[ 7 ][ 'file' ], '/the-events-calendar/' ) !== false ) {
+          return $filename;
+        }
+        return $return;
+      }
+
+    }
+
+  }
+
+}

--- a/readme.txt
+++ b/readme.txt
@@ -1,12 +1,12 @@
 === WP-Stateless - Google Cloud Storage ===
-Contributors: usability_dynamics, andypotanin, ideric, maxim.peshkov, Anton Korotkoff, planvova
+Contributors: usability_dynamics, andypotanin, ideric, maxim.peshkov, Anton Korotkoff, planvova, balexey88
 Donate link: https://udx.io
 Tags: google, google cloud, google cloud storage, cdn, uploads, media, stateless, backup
 License: GPLv2 or later
 Requires PHP: 8.0
 Requires at least: 5.0
-Tested up to: 6.2.2
-Stable tag: 3.2.4
+Tested up to: 6.3.1
+Stable tag: 3.2.5
 
 Upload and serve your WordPress media files from Google Cloud Storage.
 
@@ -61,7 +61,7 @@ For a more detailed installation and setup walkthrough, please see the [manual s
 == Screenshots ==
 
 1. Settings Panel: Supports network setting and wp-config constant overrides.
-2. Setup Assistant 
+2. Setup Assistant
 3. Setup Assistant: Google Login
 4. Setup Assistant: Approve Permissions
 5. Setup Assistant: Project & Bucket
@@ -141,7 +141,7 @@ Before upgrading to WP-Stateless 3.0, please, make sure you tested it on your de
 * FIX - Fixed vulnerability issues.
 * FIX - Fixed erros and warnings on PHP 8.
 * FIX - problem after the upgrade [#628](https://github.com/udx/wp-stateless/issues/628).
-* FIX - image_downsize() PHP8 Required parameter $id follows optional parameter $false [#619](https://github.com/udx/wp-stateless/issues/619). 
+* FIX - image_downsize() PHP8 Required parameter $id follows optional parameter $false [#619](https://github.com/udx/wp-stateless/issues/619).
 
 = 3.1.1 =
 * ENHANCEMENT - Notification for the administrator about finished synchronization. GitHub issue [#576](https://github.com/udx/wp-stateless/issues/576).

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,13 @@ Before upgrading to WP-Stateless 3.2.0, please, make sure you use PHP 7.2 or abo
 Before upgrading to WP-Stateless 3.0, please, make sure you tested it on your development environment.
 
 == Changelog ==
+= 3.2.5 =
+* FIX - Folder setting does not allow custom structure [#608](https://github.com/udx/wp-stateless/issues/608).
+* FIX - Stateless mode Incompatible with Inline Uploader [#675](https://github.com/udx/wp-stateless/issues/675).
+* FIX - html tags incorrectly applied in notice [#680](https://github.com/udx/wp-stateless/issues/680).
+* ENHANCEMENT - Add WP_STATELESS_SKIP_ACL_SET for skip ACL set for GCS [#625](https://github.com/udx/wp-stateless/issues/625).
+* COMPATIBILITY - Add support for The Events Calendar [#599](https://github.com/udx/wp-stateless/issues/599).
+
 = 3.2.4 =
 * FIX - Website unresponsive after Upgrade [#669](https://github.com/udx/wp-stateless/issues/669).
 

--- a/static/views/settings_interface.php
+++ b/static/views/settings_interface.php
@@ -182,7 +182,7 @@
                     </p>
                     <div class="sm-wildcards">
                       <select class=" select-wildcards" multiple="multiple" name="sm[root_dir][]" ng-disabled="sm.readonly.root_dir">
-                        <?php foreach ($wildcards as $wildcard => $replace) : ?>
+                        <?php foreach ($wildcards as $wildcard) : ?>
                           <option <?php echo in_array($wildcard, $root_dir_values) ? 'selected="selected"' : ""; ?> <?php echo ($wildcard == '/') ? 'disabled="disabled"' : ""; ?>><?php esc_html_e($wildcard); ?></option>
                           <?php if (in_array($wildcard, $root_dir_values) && $wildcard != '/') : ?>
                             <option selected="selected" disabled="disabled">/</option>

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -78,6 +78,7 @@ return array(
     'wpCloud\\StatelessMedia\\Sync\\ImageSync' => $baseDir . '/lib/classes/sync/class-image-sync.php',
     'wpCloud\\StatelessMedia\\Sync\\LibrarySync' => $baseDir . '/lib/classes/sync/class-library-sync.php',
     'wpCloud\\StatelessMedia\\Sync\\NonLibrarySync' => $baseDir . '/lib/classes/sync/class-non-library-sync.php',
+    'wpCloud\\StatelessMedia\\TheEventsCalendar' => $baseDir . '/lib/classes/compatibility/the-events-calendar.php',
     'wpCloud\\StatelessMedia\\UnprocessableException' => $baseDir . '/lib/classes/exception-unprocessable.php',
     'wpCloud\\StatelessMedia\\Upgrader' => $baseDir . '/lib/classes/class-upgrader.php',
     'wpCloud\\StatelessMedia\\Utility' => $baseDir . '/lib/classes/class-utility.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -202,6 +202,7 @@ class ComposerStaticInitc59d002476a452800baaf79c430753cb
         'wpCloud\\StatelessMedia\\Sync\\ImageSync' => __DIR__ . '/../..' . '/lib/classes/sync/class-image-sync.php',
         'wpCloud\\StatelessMedia\\Sync\\LibrarySync' => __DIR__ . '/../..' . '/lib/classes/sync/class-library-sync.php',
         'wpCloud\\StatelessMedia\\Sync\\NonLibrarySync' => __DIR__ . '/../..' . '/lib/classes/sync/class-non-library-sync.php',
+        'wpCloud\\StatelessMedia\\TheEventsCalendar' => __DIR__ . '/../..' . '/lib/classes/compatibility/the-events-calendar.php',
         'wpCloud\\StatelessMedia\\UnprocessableException' => __DIR__ . '/../..' . '/lib/classes/exception-unprocessable.php',
         'wpCloud\\StatelessMedia\\Upgrader' => __DIR__ . '/../..' . '/lib/classes/class-upgrader.php',
         'wpCloud\\StatelessMedia\\Utility' => __DIR__ . '/../..' . '/lib/classes/class-utility.php',

--- a/wp-stateless-media.php
+++ b/wp-stateless-media.php
@@ -8,7 +8,7 @@
  * Text Domain: stateless-media
  * Author URI: https://www.udx.io
  *
- * Copyright 2012 - 2022 UDX ( email: info@udx.io )
+ * Copyright 2012 - 2023 UDX ( email: info@udx.io )
  *
  */
 

--- a/wp-stateless-media.php
+++ b/wp-stateless-media.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://udx.io
  * Description: Upload and serve your WordPress media files from Google Cloud Storage.
  * Author: UDX
- * Version: 3.2.4
+ * Version: 3.2.5
  * Text Domain: stateless-media
  * Author URI: https://www.udx.io
  *

--- a/wp-stateless-media.php
+++ b/wp-stateless-media.php
@@ -88,7 +88,7 @@ if( !function_exists( 'ud_stateless_media_message' ) ) {
     global $_ud_stateless_media_error;
     if( !empty( $_ud_stateless_media_error ) ) {
       $message = sprintf( __( '<p><b>%s</b> can not be initialized. %s</p>', 'stateless-media' ), 'Stateless Media', $_ud_stateless_media_error );
-      echo '<div class="error fade" style="padding:11px;">' . htmlspecialchars($message) . '</div>';
+      echo '<div class="error fade" style="padding:11px;">' . $message . '</div>';
     }
   }
   add_action( 'admin_notices', 'ud_stateless_media_message' );


### PR DESCRIPTION
* FIX - Folder setting does not allow custom structure [#608](https://github.com/udx/wp-stateless/issues/608).
* FIX - Stateless mode Incompatible with Inline Uploader [#675](https://github.com/udx/wp-stateless/issues/675).
* FIX - html tags incorrectly applied in notice [#680](https://github.com/udx/wp-stateless/issues/680).
* ENHANCEMENT - Add WP_STATELESS_SKIP_ACL_SET for skip ACL set for GCS [#625](https://github.com/udx/wp-stateless/issues/625).
* COMPATIBILITY - Add support for The Events Calendar [#599](https://github.com/udx/wp-stateless/issues/599).