### PR TITLE
fix: defensively check for null post in add_fields() for php 8.3

### DIFF
--- a/vendor/wpmetabox/meta-box/inc/media-modal.php
+++ b/vendor/wpmetabox/meta-box/inc/media-modal.php
@@ -35,7 +35,10 @@ class RWMB_Media_Modal {
 	 *
 	 * @return mixed
 	 */
-	public function add_fields( $form_fields, WP_Post $post ) {
+	public function add_fields( $form_fields, ?WP_Post $post ) {
+                if (is_null($post)) {
+			return $form_fields;
+		}
 		if ( $this->is_attachment_edit_screen() ) {
 			return $form_fields;
 		}


### PR DESCRIPTION
If some posts are deleted from database, this function can be called with a null post, which is caught and throws an error in php 8.3 Make the argument nullable and check it.