### PR TITLE
set_time_limit should be set to zero for unlimited

### DIFF
--- a/lib/classes/class-ajax.php
+++ b/lib/classes/class-ajax.php
@@ -85,7 +85,7 @@ namespace wpCloud\StatelessMedia {
        * Regenerate image sizes.
        */
       public function action_stateless_process_image() {
-        @set_time_limit(-1);
+        set_time_limit(0);
 
         $image = Utility::process_image_by_id(intval($_REQUEST['id']));
 
@@ -97,7 +97,7 @@ namespace wpCloud\StatelessMedia {
        * @throws \Exception
        */
       public function action_stateless_process_file() {
-        @set_time_limit(-1);
+        set_time_limit(0);
 
         $file = Utility::process_file_by_id(intval($_REQUEST['id']));
 

--- a/lib/classes/class-gs-client.php
+++ b/lib/classes/class-gs-client.php
@@ -174,7 +174,7 @@ namespace wpCloud\StatelessMedia {
       public function add_media($args = array()) {
         try {
 
-          @set_time_limit(-1);
+          set_time_limit(0);
 
           $args = wp_parse_args($args, array(
             'use_root' => true,

--- a/lib/classes/sync/class-file-sync.php
+++ b/lib/classes/sync/class-file-sync.php
@@ -67,7 +67,7 @@ class FileSync extends LibrarySync {
       parent::before_task($id);
 
       timer_start();
-      @set_time_limit(-1);
+      set_time_limit(0);
 
       $file = Utility::process_file_by_id($id);
       $this->log(sprintf(__('%1$s (ID %2$s) was successfully synced in %3$s seconds.', ud_get_stateless_media()->domain), esc_html(get_the_title($file->ID)), $file->ID, timer_stop()));

--- a/lib/classes/sync/class-image-sync.php
+++ b/lib/classes/sync/class-image-sync.php
@@ -74,7 +74,7 @@ class ImageSync extends LibrarySync {
       parent::before_task($id);
 
       timer_start();
-      @set_time_limit(-1);
+      set_time_limit(0);
 
       $image = Utility::process_image_by_id($id);
       $this->log(sprintf(__('%1$s (ID %2$s) was successfully synced in %3$s seconds.', ud_get_stateless_media()->domain), esc_html(get_the_title($image->ID)), $image->ID, timer_stop()));

--- a/lib/cli/class-sm-cli-sync.php
+++ b/lib/cli/class-sm-cli-sync.php
@@ -94,7 +94,7 @@ class SM_CLI_Sync extends SM_CLI_Scaffold {
 
     WP_CLI::line('Starting extract attachments.');
 
-    @set_time_limit(-1);
+    set_time_limit(0);
 
     for ($this->start; $this->start < $this->end; $this->start += $this->limit) {
 
@@ -184,7 +184,7 @@ class SM_CLI_Sync extends SM_CLI_Scaffold {
 
     WP_CLI::line('Starting extract attachments.');
 
-    @set_time_limit(-1);
+    set_time_limit(0);
 
     for ($this->start; $this->start < $this->end; $this->start += $this->limit) {
 


### PR DESCRIPTION
This fixes the PHP set_time_limit method to have a value of 0 instead of -1. Zero is the correct value for "unlimited". I also removed the @ which suppresses errors.

#704 