### PR TITLE
Latest => 4.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,8 @@
 == Changelog ==
+= 4.0.2 =
+* FIX - in multisite network, deleting site can potentially remove WP-Stateless tables from another site.
+* COMPATIBILITY - Gravity Forms Compatibility updated for the newest Gravity Forms version.
+
 = 4.0.1 =
 * FIX - improvements to Data Optimization process.
 * FIX - Data Optimization fixed for multisite environment.

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,7 @@
+#### 4.0.2
+* FIX - in multisite network, deleting site can potentially remove WP-Stateless tables from another site.
+* COMPATIBILITY - Gravity Forms Compatibility updated for the newest Gravity Forms version.
+
 #### 4.0.1
 * FIX - improvements to Data Optimization process.
 * FIX - Data Optimization fixed for multisite environment.

--- a/lib/classes/class-bootstrap.php
+++ b/lib/classes/class-bootstrap.php
@@ -596,6 +596,18 @@ namespace wpCloud\StatelessMedia {
       }
 
       /**
+       * Return gs:// path.
+       *
+       * @param array $sm
+       * @return mixed|void
+       */
+      public function get_gs_path() {
+        $path = 'gs://'  . $this->get('sm.bucket');
+
+        return apply_filters('get_gs_path', $path);
+      }
+
+      /**
        * Filter for wp_stateless_bucket_link if custom domain is set.
        * It's get attachment url and remove "storage.googleapis.com" from url.
        * So that custom url can be used.
@@ -1748,11 +1760,7 @@ namespace wpCloud\StatelessMedia {
        * @param $old_site
        */
       public function wp_delete_site($old_site) {
-        switch_to_blog($old_site->id);
-
-        ud_stateless_db()->clear_db();
-        
-        restore_current_blog();
+        ud_stateless_db()->clear_db($old_site->id);
       }
 
       /**
@@ -2089,6 +2097,20 @@ namespace wpCloud\StatelessMedia {
         }
     
         wp_mail( $admin_email, $subject, $message);
+      }
+
+      /**
+       * Check if we are in specific mode
+       *
+       * @param string|array $mode
+       * @return bool
+       */
+      public function is_mode($mode) {
+        if ( !is_array($mode) ) {
+          $mode = [$mode];
+        }
+
+        return in_array($this->get('sm.mode'), $mode);
       }
     }
   }

--- a/lib/classes/class-db.php
+++ b/lib/classes/class-db.php
@@ -202,10 +202,25 @@ namespace wpCloud\StatelessMedia {
 
       /**
        * Remove custom DB table on plugin uninstall
+       * 
+       * @param int $site_id
        */
-      public function clear_db() {
-        $sql = "DROP TABLE IF EXISTS $this->files, $this->file_sizes, $this->file_meta, $this->sm_sync;";
+      public function clear_db($site_id) {
+        switch_to_blog($id);
+
+        $tables = array(
+          $this->wpdb->prefix . 'files',
+          $this->wpdb->prefix . 'files_sizes',
+          $this->wpdb->prefix . 'file_meta',
+          $this->wpdb->prefix . 'sm_sync',
+        );
+
+        $tables = implode(', ', $tables);
+
+        $sql = "DROP TABLE IF EXISTS $tables;";
         $this->wpdb->query($sql);
+
+        restore_current_blog();
       }
 
       /**

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Tags: google cloud, google cloud storage, cdn, uploads, backup
 License: GPLv2 or later
 Requires PHP: 8.0
 Requires at least: 5.0
-Tested up to: 6.5.0
-Stable tag: 4.0.1
+Tested up to: 6.5.2
+Stable tag: 4.0.2
 
 Upload and serve your WordPress media files from Google Cloud Storage.
 
@@ -121,6 +121,10 @@ Before upgrading to WP-Stateless 3.2.0, please, make sure you use PHP 7.2 or abo
 Before upgrading to WP-Stateless 3.0, please, make sure you tested it on your development environment.
 
 == Changelog ==
+= 4.0.2 =
+* FIX - in multisite network, deleting site can potentially remove WP-Stateless tables from another site.
+* COMPATIBILITY - Gravity Forms Compatibility updated for the newest Gravity Forms version.
+
 = 4.0.1 =
 * FIX - improvements to Data Optimization process.
 * FIX - Data Optimization fixed for multisite environment.

--- a/wp-stateless-media.php
+++ b/wp-stateless-media.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://stateless.udx.io/
  * Description: Upload and serve your WordPress media files from Google Cloud Storage.
  * Author: UDX
- * Version: 4.0.1
+ * Version: 4.0.2
  * Text Domain: stateless-media
  * Author URI: https://udx.io
  * License: GPLv2 or later


### PR DESCRIPTION
* FIX - in multisite network, deleting site can potentially remove WP-Stateless tables from another site.
* COMPATIBILITY - Gravity Forms Compatibility updated for the newest Gravity Forms version.
