### PR TITLE
4.0.3 - Info section and minor fixes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,18 @@
 == Changelog ==
+= 4.0.3 =
+* NEW - added `Info` section to the `Status` tab on the Settings page, which contains the system info and the ability to copy report to clipboard.  
+* ENHANCEMENT - added `Documentation` link on the Plugins page.
+* ENHANCEMENT - added `Addons` link on the Plugins page.
+* ENHANCEMENT - added `Documentation` link on the Settings page.
+* FIX - fixed `Settings` shortcut on the Plugins page.
+* FIX - in multisite network, do not show Data Optimization on the Network Admin Page.
+* FIX - properly set `Content Disposition` fields for media objects.
+* FIX - properly use `Cache Control` setting for media objects.
+* FIX - fixed `Creation of dynamic property` PHP deprecation notice.
+* FIX - fixed `Cannot use ::class with dynamic class name` PHP warning.
+* FIX - avoid PHP warning when unable to get file path in `Stateless` mode [728](https://github.com/udx/wp-stateless/issues/728).
+* FIX - fixed links to the constants documentation.
+
 = 4.0.2 =
 * FIX - in multisite network, deleting site can potentially remove WP-Stateless tables from another site.
 * COMPATIBILITY - Gravity Forms Compatibility updated for the newest Gravity Forms version.

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,17 @@
+#### 4.0.3
+* NEW - added `Info` section to the `Status` tab on the Settings page, which contains the system info and the ability to copy report to clipboard.  
+* ENHANCEMENT - added `Documentation` link on the Plugins page.
+* ENHANCEMENT - added `Addons` link on the Plugins page.
+* ENHANCEMENT - added `Documentation` link on the Settings page.
+* FIX - fixed `Settings` shortcut on the Plugins page.
+* FIX - in multisite network, do not show Data Optimization on the Network Admin Page.
+* FIX - properly set `Content Disposition` fields for media objects.
+* FIX - properly use `Cache Control` setting for media objects.
+* FIX - fixed `Creation of dynamic property` PHP deprecation notice.
+* FIX - fixed `Cannot use ::class with dynamic class name` PHP warning.
+* FIX - avoid PHP warning when unable to get file path in `Stateless` mode [728](https://github.com/udx/wp-stateless/issues/728).
+* FIX - fixed links to the constants documentation.
+
 #### 4.0.2
 * FIX - in multisite network, deleting site can potentially remove WP-Stateless tables from another site.
 * COMPATIBILITY - Gravity Forms Compatibility updated for the newest Gravity Forms version.

--- a/lib/classes/batch/class-batch-task-manager.php
+++ b/lib/classes/batch/class-batch-task-manager.php
@@ -230,7 +230,7 @@ class BatchTaskManager extends \UDX_WP_Background_Process {
     // Check if we have more batched to run
     try {
       $object = $this->_get_batch_task_object();
-      $class = $object::class;  
+      $class = get_class($object);
       $batch = $object->get_batch();
 
       if ( !empty($batch) ) {
@@ -242,7 +242,7 @@ class BatchTaskManager extends \UDX_WP_Background_Process {
         return;
       }
 
-      Helper::log( 'Batch task completed: ' . $object::class );
+      Helper::log( 'Batch task completed: ' . $class );
     } catch (\Throwable $e) {
       Helper::log( "Unable to process next batch: " . $e->getMessage() );
     }

--- a/lib/classes/class-addons.php
+++ b/lib/classes/class-addons.php
@@ -203,7 +203,7 @@ namespace wpCloud\StatelessMedia {
       $plugin_desc = __('Provides compatibility between the %s and the WP-Stateless plugins.', ud_get_stateless_media()->domain);
       $theme_desc = __('Provides compatibility between the %s theme and the WP-Stateless plugin.', ud_get_stateless_media()->domain);
 
-      $link = 'https://stateless.udx.io/addons/%s';
+      $link = ud_get_stateless_media()->get_docs_page_url('addons/%s');
 
       $defaults = [
         'title'         => '',

--- a/lib/classes/class-db.php
+++ b/lib/classes/class-db.php
@@ -14,6 +14,7 @@ namespace wpCloud\StatelessMedia {
     class DB {
       use Singleton;
 
+      const DB_VERSION_KEY = 'sm_db_version';
       const DB_VERSION = '1.0';
       const FULL_SIZE = '__full';
 
@@ -140,7 +141,7 @@ namespace wpCloud\StatelessMedia {
        * Creates or updates DB structure
        */
       public function create_db() {
-        $version = get_option('sm_db_version');
+        $version = get_option(self::DB_VERSION_KEY, '');
 
         if ($version === self::DB_VERSION) {
           return;
@@ -197,7 +198,7 @@ namespace wpCloud\StatelessMedia {
         require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
         dbDelta($sql);
 
-        update_option('sm_db_version', self::DB_VERSION);
+        update_option(self::DB_VERSION_KEY, self::DB_VERSION);
       }
 
       /**
@@ -703,7 +704,24 @@ namespace wpCloud\StatelessMedia {
         global $wpdb;
 
         try {
-          $query = "SELECT COUNT(post_id) FROM $this->files";
+          $query = "SELECT COUNT(id) FROM $this->files";
+
+          return $wpdb->get_var($query);
+        } catch (\Throwable $e) {
+          return 0;
+        }
+      }
+
+      /**
+       * Get the total file sizes count known to WP-Stateless
+       * 
+       * @return int
+       */
+      public function get_total_file_sizes() {
+        global $wpdb;
+
+        try {
+          $query = "SELECT COUNT(id) FROM $this->file_sizes";
 
           return $wpdb->get_var($query);
         } catch (\Throwable $e) {

--- a/lib/classes/class-dynamic-image-support.php
+++ b/lib/classes/class-dynamic-image-support.php
@@ -75,7 +75,7 @@ namespace wpCloud\StatelessMedia {
         $client->add_media(apply_filters('sm:item:on_fly:before_add', array_filter(array(
           'name' => $file_path,
           'absolutePath' => wp_normalize_path($file),
-          'cacheControl' => apply_filters('sm:item:cacheControl', 'public, max-age=36000, must-revalidate', $_metadata),
+          'cacheControl' => apply_filters('sm:item:cacheControl', ud_get_stateless_media()->get_default_cache_control(), $_metadata),
           'contentDisposition' => null,
           'mimeType' => $mimeType['type'],
           'metadata' => $_metadata

--- a/lib/classes/class-gs-client.php
+++ b/lib/classes/class-gs-client.php
@@ -54,6 +54,11 @@ namespace wpCloud\StatelessMedia {
       private $temp_objects = array();
 
       /**
+       * @var
+       */
+      private $key_json = '';
+
+      /**
        * Constructor.
        * Must not be called directly.
        *
@@ -220,7 +225,7 @@ namespace wpCloud\StatelessMedia {
           }
 
           if (isset($args['contentDisposition'])) {
-            $media->getContentDisposition($args['contentDisposition']);
+            $media->setContentDisposition($args['contentDisposition']);
           }
 
           // If chunk size is defined, we assume user needs the file to be sent by chunks

--- a/lib/classes/class-migrator.php
+++ b/lib/classes/class-migrator.php
@@ -229,6 +229,10 @@ class Migrator {
    * Outputs the message that migrations are required
    */
   public function show_messages() {
+    if ( is_network_admin() ) {
+      return;
+    }
+
     $is_running = BatchTaskManager::instance()->is_processing() || BatchTaskManager::instance()->is_paused();
     $notify = get_option(self::MIGRATIONS_NOTIFY_KEY, false);
 

--- a/lib/classes/class-sync-non-media.php
+++ b/lib/classes/class-sync-non-media.php
@@ -144,7 +144,7 @@ namespace wpCloud\StatelessMedia {
             try {
               $media = $object->update(array('metadata' => $args['metadata']) +
                 array(
-                  'cacheControl' => apply_filters('sm:item:cacheControl', 'public, max-age=36000, must-revalidate', $absolutePath),
+                  'cacheControl' => apply_filters('sm:item:cacheControl', ud_get_stateless_media()->get_default_cache_control(), $absolutePath),
                   'predefinedAcl' => 'publicRead',
                   'contentDisposition' => apply_filters('sm:item:contentDisposition', null, $absolutePath)
                 ));
@@ -157,7 +157,7 @@ namespace wpCloud\StatelessMedia {
               'name' => $name,
               'force' => ($forced == 2),
               'absolutePath' => $absolutePath,
-              'cacheControl' => apply_filters('sm:item:cacheControl', 'public, max-age=36000, must-revalidate', $absolutePath), //@todo use cacheControl from settings page.
+              'cacheControl' => apply_filters('sm:item:cacheControl', ud_get_stateless_media()->get_default_cache_control(), $absolutePath), //@todo use cacheControl from settings page.
               'contentDisposition' => apply_filters('sm:item:contentDisposition', null, $absolutePath),
               'mimeType' => $file_type,
               'metadata' => array(

--- a/lib/classes/class-utility.php
+++ b/lib/classes/class-utility.php
@@ -46,15 +46,6 @@ namespace wpCloud\StatelessMedia {
       }
 
       /**
-       * Override Cache Control
-       * @param $cacheControl
-       * @return mixed
-       */
-      public static function override_cache_control($cacheControl) {
-        return ud_get_stateless_media()->get('sm.cache_control');
-      }
-
-      /**
        * wp_normalize_path was added in 3.9.0
        *
        * @param $path
@@ -141,7 +132,7 @@ namespace wpCloud\StatelessMedia {
 
         // Treat images as public.
         if (strpos($_mime_type, 'image/') !== false) {
-          return apply_filters('sm:item:cacheControl', 'public, max-age=36000, must-revalidate', array('attachment_id' => $attachment_id, 'mime_type' => null, 'metadata' => $metadata, 'data' => $data));
+          return apply_filters('sm:item:cacheControl', ud_get_stateless_media()->get_default_cache_control(), array('attachment_id' => $attachment_id, 'mime_type' => null, 'metadata' => $metadata, 'data' => $data));
         }
 
         // Treat images as public.

--- a/lib/classes/status/class-info-stateless.php
+++ b/lib/classes/status/class-info-stateless.php
@@ -1,0 +1,393 @@
+<?php
+/**
+ * System Info (Stateless section) class
+ *
+ * @since 4.1.0
+ */
+
+namespace wpCloud\StatelessMedia\Status;
+
+use wpCloud\StatelessMedia\Singleton;
+use wpCloud\StatelessMedia\Helper;
+
+class StatelessInfo {
+  use Singleton;
+
+  /**
+   * Stateless settings
+   * 
+   * @var array|null
+   */
+  private $settings = null;
+
+  protected function __construct() {
+    $this->_init_hooks();
+  }
+
+  private function _init_hooks() {
+    add_filter('wp_stateless_status_info_values_stateless', [$this, 'get_settings_values'], 10);
+    add_filter('wp_stateless_status_info_values_stateless', [$this, 'get_settings_constants'], 20);
+    add_filter('wp_stateless_status_info_values_stateless', [$this, 'get_media_stats'], 30);
+    add_filter('wp_stateless_status_info_values_stateless', [$this, 'prepare_values'], 99);
+
+    add_filter('wp_stateless_status_info_stateless_value', [$this, 'format_value'], 10, 3);
+    
+    add_filter('wp_stateless_status_info_stateless_value_mode', [$this, 'get_mode'], 10);
+    add_filter('wp_stateless_status_info_stateless_value_body_rewrite', [$this, 'get_body_rewrite'], 10);
+    add_filter('wp_stateless_status_info_stateless_value_bucket', [$this, 'get_is_set'], 10);
+    add_filter('wp_stateless_status_info_stateless_value_bucket_accessible', [$this, 'get_yes_no_value'], 10);
+    add_filter('wp_stateless_status_info_stateless_value_key_json', [$this, 'get_is_set'], 10);
+    add_filter('wp_stateless_status_info_stateless_value_cache_control', [$this, 'get_cache_control'], 10);
+    add_filter('wp_stateless_status_info_stateless_value_delete_remote', [$this, 'get_enabled_value'], 10);
+    add_filter('wp_stateless_status_info_stateless_value_root_dir', [$this, 'get_root_dir'], 10);
+    add_filter('wp_stateless_status_info_stateless_value_custom_domain', [$this, 'get_is_set'], 10);
+    add_filter('wp_stateless_status_info_stateless_value_hashify_file_name', [$this, 'get_enabled_value'], 10);
+    add_filter('wp_stateless_status_info_stateless_value_dynamic_image_support', [$this, 'get_enabled_value'], 10);
+    add_filter('wp_stateless_status_info_stateless_value_use_postmeta', [$this, 'get_enabled_value'], 10);
+    add_filter('wp_stateless_status_info_stateless_value_WP_STATELESS_LEGACY_URL_TO_POSTID', [$this, 'get_yes_no_value'], 10);
+    add_filter('wp_stateless_status_info_stateless_value_WP_STATELESS_SKIP_ACL_SET', [$this, 'get_yes_no_value'], 10);
+  }
+
+  /**
+   * Get settings
+   * 
+   * @return array
+   */
+  private function _get_setings() {
+    if ( empty($this->settings) ) {
+      $this->settings = ud_get_stateless_media()->get('sm');
+    }
+
+    return $this->settings;
+  }
+
+  /**
+   * Format mode setting
+   * 
+   * @param string $value
+   * @return string
+   */
+  public function get_mode($value) {
+    switch ($value) {
+      case '':
+        $value = __('Don\'t override', ud_get_stateless_media()->domain);
+        break;
+      case 'disabled':
+        $value = __('Disabled', ud_get_stateless_media()->domain);
+        break;
+      case 'backup':
+        $value = __('Backup', ud_get_stateless_media()->domain);
+        break;
+      case 'cdn':
+        $value = __('CDN', ud_get_stateless_media()->domain);
+        break;
+      case 'ephemeral':
+        $value = __('Ephemeral', ud_get_stateless_media()->domain);
+        break;
+      case 'stateless':
+        $value = __('Stateless', ud_get_stateless_media()->domain);
+        break;
+    }
+
+    return $value;
+  } 
+
+  /**
+   * Get body_rewrite setting
+   * 
+   * @param string $value
+   * @return string
+   */
+  public function get_body_rewrite($value) {
+    switch ($value) {
+      case '':
+        $value = __('Don\'t override', ud_get_stateless_media()->domain);
+        break;
+      case 'false':
+        $value = __('Disabled', ud_get_stateless_media()->domain);
+        break;
+      case 'enable_editor':
+        $value = __('Enable Editor', ud_get_stateless_media()->domain);
+        break;
+      case 'enable_meta':
+        $value = __('Enable Meta', ud_get_stateless_media()->domain);
+        break;
+      case 'true':
+        $value = __('Enable Editor & Meta', ud_get_stateless_media()->domain);
+        break;
+    }
+
+    return $value;
+  } 
+
+  /**
+   * Format Cache Control setting
+   * 
+   * @param bool $value
+   * @return string
+   */
+  public function get_cache_control($value) {
+    if ( empty($value) ) {
+      $value = sprintf( __('Default: %s', ud_get_stateless_media()->domain), ud_get_stateless_media()->get_default_cache_control() );
+    }
+
+    return $value;
+  }
+
+  /**
+   * Format Folder setting
+   * 
+   * @param bool $value
+   * @return string
+   */
+  public function get_root_dir($value) {
+    if ( empty($value) && is_network_admin() ) {
+      $value = __('Don\'t override', ud_get_stateless_media()->domain);
+    }
+
+    return $value;
+  }
+
+  /**
+   * Format the value if it is set or not
+   * 
+   * @param bool $value
+   * @return string
+   */
+  public function get_is_set($value) {
+    return (bool) $value ? __('Set', ud_get_stateless_media()->domain) : __('Not set', ud_get_stateless_media()->domain);
+  }
+
+  /**
+   * Get boolean value (Yes/No)
+   * 
+   * @param bool $value
+   * @return string
+   */
+  public function get_yes_no_value($value) {
+    return (bool) $value ? __('Yes', ud_get_stateless_media()->domain) : __('No', ud_get_stateless_media()->domain);
+  }
+
+  /**
+   * Get boolean value (Enable/Disabled)
+   * 
+   * @param bool $value
+   * @return string
+   */
+  public function get_enabled_value($value) {
+    switch ($value) {
+      case '':
+        $value = __('Don\'t override', ud_get_stateless_media()->domain);
+        break;
+      case 'true':
+        $value = __('Enable', ud_get_stateless_media()->domain);
+        break;
+      case 'false':
+        $value = __('Disable', ud_get_stateless_media()->domain);
+        break;
+    }
+
+    return $value;
+  }
+
+  /**
+   * Format stateless settings value
+   * 
+   * @param string $value
+   * @param string $key
+   * @param array $sm
+   * 
+   * @return string
+   */
+  public function format_value($value, $key, $sm) {
+    $value = apply_filters("wp_stateless_status_info_stateless_value_$key", $value, $sm);
+
+    $readonly = array_keys( $sm['readonly'] ?? [] );
+
+    if ( in_array($key, $readonly)) {
+      $type = $sm['readonly'][$key] ?? '';
+
+      $suffix = '';
+      $hint = $sm['strings'][$type] ?? '';
+
+      switch ($type) {
+        case 'network':
+          $suffix = __('Network', ud_get_stateless_media()->domain);
+          break;
+        case 'constant':
+          $suffix = __('Constant', ud_get_stateless_media()->domain);
+          break;
+        case 'environment':
+          $suffix = __('Environment', ud_get_stateless_media()->domain);
+          break;
+      }
+  
+      if ( !empty($suffix) ) {
+        $value = sprintf(
+          '<div class="stateless-info-table-extended-value">'.
+            '<span>%s</span> '.
+            '<span title="%s"><em>(</em>%s%s<em>)</em></span>'.
+          '</div', 
+          $value,
+          $hint,
+          '<span class="dashicons dashicons-editor-help"></span>',
+          $suffix,
+        );
+      }
+    }
+
+    return $value;
+  }
+
+  /**
+   * Get WP-Stateless settings
+   * 
+   * @param array $values
+   * @return array
+   */
+  public function get_settings_values($values) {
+    $sm = $this->_get_setings();
+
+    $rows = [
+      'version' => [
+        'label' => __('Version', ud_get_stateless_media()->domain),
+        'value' => ud_get_stateless_media()::$version,
+      ],
+      'db_version' => [
+        'label' => __('Database Version', ud_get_stateless_media()->domain),
+        'value' => get_option( ud_stateless_db()::DB_VERSION_KEY, '' ),
+      ],
+      'mode' => [
+        'label' => __('Mode', ud_get_stateless_media()->domain),
+        'value' => $sm['mode'],
+      ],
+      'body_rewrite' => [
+        'label' => __('File URL Replacement', ud_get_stateless_media()->domain),
+        'value' => $sm['body_rewrite'],
+      ],
+      'body_rewrite_types' => [
+        'label' => __('Supported File Types', ud_get_stateless_media()->domain),
+        'value' => $sm['body_rewrite_types'],
+      ],
+      'bucket' => [
+        'label' => __('Bucket', ud_get_stateless_media()->domain),
+        'value' => !empty($sm['bucket']),
+      ],
+      'bucket_accessible' => [
+        'label' => __('Bucket Accessible', ud_get_stateless_media()->domain),
+        'value' => get_transient('sm::is_connected_to_gs'),
+      ],
+      'key_json' => [
+        'label' => __('Service Account JSON', ud_get_stateless_media()->domain),
+        'value' => !empty($sm['key_json']),
+      ],
+      'cache_control' => [
+        'label' => __('Cache-Control', ud_get_stateless_media()->domain),
+        'value' => $sm['cache_control'],
+      ],
+      'delete_remote' => [
+        'label' => __('Delete GCS File', ud_get_stateless_media()->domain),
+        'value' => $sm['delete_remote'],
+      ],
+      'root_dir' => [
+        'label' => __('Folder', ud_get_stateless_media()->domain),
+        'value' => $sm['root_dir'],
+      ],
+      'custom_domain' => [
+        'label' => __('Domain', ud_get_stateless_media()->domain),
+        'value' => !empty($sm['custom_domain']),
+      ],
+      'hashify_file_name' => [
+        'label' => __('Cache-Busting', ud_get_stateless_media()->domain),
+        'value' => $sm['hashify_file_name'],
+      ],
+      'dynamic_image_support' => [
+        'label' => __('Dynamic Image Support', ud_get_stateless_media()->domain),
+        'value' => $sm['dynamic_image_support'],
+      ],
+      'use_postmeta' => [
+        'label' => __('Use Post Meta', ud_get_stateless_media()->domain),
+        'value' => $sm['use_postmeta'],
+      ],
+    ];
+
+    return $values + $rows;
+  }
+
+  /**
+   * Get constants settings, not available on Settings page
+   * 
+   * @param array $values
+   * @return array
+   */
+  public function get_settings_constants($values) {
+    $sm = $this->_get_setings();
+
+    $constants = [
+      'WP_STATELESS_MEDIA_UPLOAD_CHUNK_SIZE' => __('Upload Chunk Size', ud_get_stateless_media()->domain),
+      'WP_STATELESS_SYNC_MAX_BATCH_SIZE' => __('Sync Max Batch Size', ud_get_stateless_media()->domain),
+      'WP_STATELESS_LEGACY_URL_TO_POSTID' => __('Change the Bucket Folder (root_dir) after uploading the image', ud_get_stateless_media()->domain),
+      'WP_STATELESS_SKIP_ACL_SET' => __('Skip setting file-level ACl when <strong>uniform bucket-level access</strong> is enabled', ud_get_stateless_media()->domain),
+    ];
+
+    $rows = [];
+
+    foreach ($constants as $key => $label) {
+      if ( !defined($key) ) {
+        continue;
+      }
+
+      // Mark all constants as readonly 'constant'
+      $this->settings['readonly'][$key] = 'constant';
+
+      $rows[$key] = [
+        'label' => $label,
+        'value' => constant($key),
+      ];
+    }
+
+    return $values + $rows;
+  }
+
+  /**
+   * Get media stats
+   * 
+   * @param array $values
+   * @return array
+   */
+  public function get_media_stats($values) {
+    if (is_network_admin()) {
+      return $values;
+    }
+
+    $compatibility_files = array_filter(array_unique(apply_filters('sm:sync::nonMediaFiles', [])));
+    $compatibility_files = count($compatibility_files);
+
+    $rows = [
+      'files' => [
+        'label' => __('Total Files', ud_get_stateless_media()->domain),
+        'value' => ud_stateless_db()->get_total_files(),
+      ],
+      'file_sizes' => [
+        'label' => __('Total File Sizes', ud_get_stateless_media()->domain),
+        'value' => ud_stateless_db()->get_total_file_sizes(),
+      ],
+      'compatibility_files' => [
+        'label' => __('Compatibility Files', ud_get_stateless_media()->domain),
+        'value' => $compatibility_files,
+      ],
+    ];
+
+    return $values + $rows;
+  }
+
+  public function prepare_values($values) {
+    $sm = $this->_get_setings();
+
+    foreach ($values as $key => $value) {
+      $values[$key]['value'] = apply_filters('wp_stateless_status_info_stateless_value', $value['value'], $key, $sm);
+    }
+
+    return $values;
+  }
+}

--- a/lib/classes/status/class-info.php
+++ b/lib/classes/status/class-info.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Migrations status class
+ * System Info class
  *
- * @since 4.0.0
+ * @since 4.1.0
  */
 
 namespace wpCloud\StatelessMedia\Status;
@@ -13,72 +13,360 @@ use wpCloud\StatelessMedia\Helper;
 class Info {
   use Singleton;
 
-  /**
-   * Migrations data
-   * 
-   * @var array
-   */
-  private $migrations = [];
-
-  /**
-   * Primary migration id (that need to run first)
-   * 
-   * @var string
-   */
-  private $primary_migration_id = '';
-
-  /**
-   * Migration id that is currently in progress (running or paused)
-   * 
-   * @var string
-   */
-  private $running_migration_id = '';
-
   protected function __construct() {
+    StatelessInfo::instance();
+
     $this->_init_hooks();
   }
 
   private function _init_hooks() {
-    // add_action('wp_stateless_status_tab_content', [$this, 'tab_content'], 10);
+    add_action('wp_stateless_status_tab_content', [$this, 'tab_content'], 10);
+
+    add_filter('wp_stateless_status_info_values_server', [$this, 'get_server_values'], 10);
+    add_filter('wp_stateless_status_info_values_server', [$this, 'get_php_values'], 20);
+    add_filter('wp_stateless_status_info_values_server', [$this, 'get_php_modules'], 30);
+
+    add_filter('wp_stateless_status_info_values_wordpress', [$this, 'get_wordpress_network_values'], 10);
+    add_filter('wp_stateless_status_info_values_wordpress', [$this, 'get_wordpress_attachments'], 20);
+    add_filter('wp_stateless_status_info_values_wordpress', [$this, 'get_wordpress_theme'], 30);
+    add_filter('wp_stateless_status_info_values_wordpress', [$this, 'get_wordpress_plugins'], 40);
   }
 
   /**
-   * Get the total attachments count
+   * Get boolean value (Yes/No)
    * 
-   * @return int
+   * @param bool $value
+   * @return string
    */
-  private function _get_total_attachments() {
+  private function _get_bool_value($value) {
+    return (bool) $value ? __('Yes', ud_get_stateless_media()->domain) : __('No', ud_get_stateless_media()->domain);
+  }
+
+  /**
+   * Get server values
+   * 
+   * @return array
+   */
+  public function get_server_values($values = []) {
     global $wpdb;
 
-    try {
-      $query = "SELECT COUNT(*) " .
-        "FROM $wpdb->posts " . 
-        "WHERE post_type = 'attachment' AND post_status != 'trash'";
+    $server_architecture = function_exists( 'php_uname' ) 
+    ? [ php_uname('s'), php_uname('r'), php_uname('m') ]
+    : [ __('Unknown', ud_get_stateless_media()->domain) ];
 
-      return $wpdb->get_var($query);
-    } catch (\Throwable $e) {
-      return 0;
-    }
-
-    return wp_count_attachments();
-  }
-
-  /**
-   * Outputs 'Health Status' tab content on the settings page.
-   */
-  public function tab_content() {    
     $rows = [
-      [
-        'label' => __('Total Attachments in Wordpress', ud_get_stateless_media()->domain),
-        'value' => $this->_get_total_attachments(),
+      'server_architecture' => [
+        'label' => __('Server architecture', ud_get_stateless_media()->domain),
+        'value' => implode(' ', $server_architecture),
       ],
-      [
-        'label' => __('Total Attachments in WP-Stateless', ud_get_stateless_media()->domain),
-        'value' => ud_stateless_db()->get_total_files(),
+      'web_server' => [
+        'label' => __('Web server', ud_get_stateless_media()->domain),
+        'value' => isset($_SERVER['SERVER_SOFTWARE']) ? $_SERVER['SERVER_SOFTWARE'] : __('Unknown', ud_get_stateless_media()->domain),
+      ],
+      'mysql' => [
+        'label' => __('MySQL version', ud_get_stateless_media()->domain),
+        'value' => $wpdb->db_server_info(),
+      ],
+      'php' => [
+        'label' => __('PHP Version', ud_get_stateless_media()->domain),
+        'value' => PHP_VERSION,
       ],
     ];
 
-    $rows = Helper::array_of_objects($rows);
+    return $values + $rows;
+  }
+
+  /**
+   * Get PHP ini values
+   * 
+   * @return array
+   */
+  public function get_php_values($values = []) {
+    if ( !function_exists('ini_get') ) {
+      $values['php_ini_get'] = [
+        'label' => __('PHP Config', ud_get_stateless_media()->domain),
+        'value' => __('Unable to determine some settings, init_get() is disabled.', ud_get_stateless_media()->domain),
+      ];
+
+      return $values;
+    }
+
+    $rows = [
+      'php_memory_limit' => [
+        'label' => __('PHP Memory Limit', ud_get_stateless_media()->domain),
+        'value' => ini_get('memory_limit'),
+      ],
+      'php_max_input_vars' => [
+        'label' => __('PHP Max Input Vars', ud_get_stateless_media()->domain),
+        'value' => ini_get('max_input_vars'),
+      ],
+      'php_max_post_size' => [
+        'label' => __('PHP Max Post Size', ud_get_stateless_media()->domain),
+        'value' => ini_get('post_max_size'),
+      ],
+      'php_time_limit' => [
+        'label' => __('PHP Time Limit', ud_get_stateless_media()->domain),
+        'value' => ini_get('max_execution_time'),
+      ],
+      'max_upload_size' => [
+        'label' => __('Max Upload Size', ud_get_stateless_media()->domain),
+        'value' => ini_get('upload_max_filesize'),
+      ],
+      'allow_url_fopen' => [
+        'label' => __('Allow URL-aware fopen Wrappers', ud_get_stateless_media()->domain),
+        'value' => $this->_get_bool_value( ini_get('allow_url_fopen') ),
+      ],
+    ];
+
+    return $values + $rows;
+  }
+
+  /**
+   * Get PHP modules
+   * 
+   * @return array
+   */
+  public function get_php_modules($values = []) {
+    $values['extensions'] = [
+      'label' => __('Loaded Extensions', ud_get_stateless_media()->domain),
+      'value' => implode(', ', get_loaded_extensions()),
+    ];
+
+    return $values;
+  }
+
+  /**
+   * Get WP global network values
+   * 
+   * @return array
+   */
+  public function get_wordpress_network_values($values = []) {
+    $rows = [
+      'version' => [
+        'label' => __('Version', ud_get_stateless_media()->domain),
+        'value' => get_bloginfo('version'),
+      ],
+      'multisite' => [
+        'label' => __('Multisite', ud_get_stateless_media()->domain),
+        'value' => $this->_get_bool_value( is_multisite() ),
+      ],
+      'memory_limit' => [
+        'label' => __('Memory Limit', ud_get_stateless_media()->domain),
+        'value' => WP_MEMORY_LIMIT,
+      ],
+    ];
+
+    return $values + $rows;
+  }
+
+  /**
+   * Format WP theme value
+   * 
+   * @param \WP_Theme $theme
+   * @return string|null
+   */
+  private function _format_theme_value($theme) {
+    if ( !is_a($theme, '\WP_Theme') ) {
+      return null;
+    }
+
+    $value = [$theme->name, $theme->version];
+
+    return implode(' ', $value);
+  }
+
+  /**
+   * Get WP attachments info
+   * 
+   * @return array
+   */
+  public function get_wordpress_attachments($values = []) {
+    if ( is_network_admin() ) {
+      return $values;
+    }
+
+    $query = new \WP_Query([
+      'post_type' => 'attachment',
+      'post_status' => 'any',
+      'posts_per_page' => -1,
+    ]);
+
+    $total = $query->found_posts;
+
+    $sizes = get_intermediate_image_sizes();
+
+    $rows = [
+      'total_attachments' => [
+        'label' => __('Total Attachments', ud_get_stateless_media()->domain),
+        'value' => $total,
+      ],
+      'image_sizes' => [
+        'label' => __('Image Sizes', ud_get_stateless_media()->domain),
+        'value' => implode(', ', $sizes)
+      ],
+    ];
+
+    return $values + $rows;
+  }
+
+  /**
+   * Get WP theme values
+   * 
+   * @return array
+   */
+  public function get_wordpress_theme($values = []) {
+    if ( is_network_admin() ) {
+      return $values;
+    }
+
+    $theme = wp_get_theme();
+
+    if ( !is_a($theme, '\WP_Theme') ) {
+      return $values;
+    }
+
+    $rows = [
+      'theme' => [
+        'label' => __('Theme', ud_get_stateless_media()->domain),
+        'value' => $this->_format_theme_value($theme),
+      ],
+    ];
+
+    $parent = $theme->parent();
+
+    if ( is_a($parent, '\WP_Theme') ) {
+      $rows['parent_theme'] = [
+        'label' => __('Parent Theme', ud_get_stateless_media()->domain),
+        'value' => $this->_format_theme_value($parent),
+      ];
+    }
+
+    return $values + $rows;
+  }
+
+  /**
+   * Format WP plugin value
+   * 
+   * @param array $plugin
+   * @param bool $is_network
+   * @return string
+   */
+  private function _format_plugin_value($plugin, $is_network = false) {
+    $value = [$plugin['Name'], $plugin['Version']];
+
+    if ($is_network) {
+      $value[] = __('(network)', ud_get_stateless_media()->domain);
+    }
+
+    return implode(' ', $value);
+  }
+
+  /**
+   * Get WP plugins list
+   * 
+   * @return array
+   */
+  public function get_wordpress_plugins($values = []) {
+    if ( is_network_admin() ) {
+      return $values;
+    }
+
+    $result = [];
+
+    $plugins = get_plugins();
+    $active_plugins = (array) get_option( 'active_plugins', [] );
+    $network_plugins = (array) get_site_option( 'active_sitewide_plugins', [] );
+    $network_plugins = array_keys($network_plugins);
+
+    foreach ($plugins as $file => $plugin) {
+      if ( in_array($file, $network_plugins) ) {
+        $result[] = $this->_format_plugin_value($plugin, true);
+
+        continue;
+      }
+
+      if ( in_array($file, $active_plugins) ) {
+        $result[] = $this->_format_plugin_value($plugin);
+      }
+    }
+  
+    $values['active_plugins'] = [
+      'label' => __('Active Plugins', ud_get_stateless_media()->domain),
+      'value' => implode(', ', $result),
+    ];
+
+    return $values;
+  }
+
+  /**
+   * Get section values
+   * 
+   * @param string $key
+   * @return array|null
+   */
+  private function _get_section_values($key) {
+    try {
+      $values = apply_filters("wp_stateless_status_info_values_$key", []);
+    } catch (\Throwable $e) {
+      $values = [
+        'error' => [
+          'label' => __('Error', ud_get_stateless_media()->domain),
+          'value' => $e->getMessage(),
+        ],
+      ];
+    }
+
+    return empty($values) ? null : Helper::array_of_objects($values);
+  }
+
+  private function _prepare_copy_text($sections) {
+    $text = '';
+
+    foreach ($sections as $section) {
+      $text .= '### ' . $section->title . PHP_EOL . PHP_EOL;
+
+      foreach ($section->rows as $row) {
+        $text .= sprintf('%s: %s%s',
+          strip_tags($row->label),
+          strip_tags($row->value),
+          PHP_EOL
+        );
+      }
+
+      $text .= PHP_EOL;
+    }
+
+    return sprintf('```%s%s```', PHP_EOL, $text);
+  }
+
+  /**
+   * Outputs 'Info' section content on Status tab.
+   */
+  public function tab_content() {
+    $sections = [
+      'server' => [
+        'title' => __('Server', ud_get_stateless_media()->domain),
+      ],
+      'wordpress' => [
+        'title' => __('WordPress', ud_get_stateless_media()->domain),
+      ],
+      'stateless' => [
+        'title' => __('WP-Stateless', ud_get_stateless_media()->domain),
+      ],
+    ];
+
+    foreach ($sections as $key => $section) {
+      $rows = $this->_get_section_values($key);
+
+      if ( !empty($rows) ) {
+        $sections[$key]['rows'] = $rows;
+      } else {
+        unset($sections[$key]);
+      }
+    }
+
+    $sections = Helper::array_of_objects($sections);
+    $copy_text = $this->_prepare_copy_text($sections);
 
     include ud_get_stateless_media()->path('static/views/status-sections/info.php', 'dir');
   }

--- a/lib/classes/status/class-migrations.php
+++ b/lib/classes/status/class-migrations.php
@@ -212,6 +212,10 @@ class Migrations {
    * Outputs 'Data Updates' section on the Status tab on the Settings page.
    */
   public function tab_content() {
+    if ( is_network_admin() ) {
+      return;
+    }
+
     $migrations = $this->_get_migrations_state();
 
     if ( !empty($migrations) ) {

--- a/lib/classes/sync/class-background-sync.php
+++ b/lib/classes/sync/class-background-sync.php
@@ -96,10 +96,11 @@ abstract class BackgroundSync extends UDX_WP_Background_Process implements ISync
       // Add notice
       $this->save_process_meta([
         'notice' => sprintf(
-          __("Not enough memory to process the following item '%s' %s: %s. Item skipped. Please, try to increase memory limit or use uploading by chunks: <a target=\"_blank\" href=\"https://stateless.udx.io/docs/constants/#wp_stateless_media_upload_chunk_size\">How to use WP_STATELESS_MEDIA_UPLOAD_CHUNK_SIZE setting.</a>", ud_get_stateless_media()->domain),
+          __("Not enough memory to process the following item '%s' %s: %s. Item skipped. Please, try to increase memory limit or use uploading by chunks: <a target=\"_blank\" href=\"%s\">How to use WP_STATELESS_MEDIA_UPLOAD_CHUNK_SIZE setting.</a>", ud_get_stateless_media()->domain),
           is_numeric($this->currently_processing_item) ? get_the_title($this->currently_processing_item) : $this->currently_processing_item,
           is_numeric($this->currently_processing_item) ? "(ID: {$this->currently_processing_item})" : '',
-          $err['message']
+          $err['message'],
+          ud_get_stateless_media()->get_docs_page_url('docs/constants/#wpstatelessmediauploadchunksize'),
         )
       ]);
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ License: GPLv2 or later
 Requires PHP: 8.0
 Requires at least: 5.0
 Tested up to: 6.5.2
-Stable tag: 4.0.2
+Stable tag: 4.0.3
 
 Upload and serve your WordPress media files from Google Cloud Storage.
 
@@ -121,6 +121,20 @@ Before upgrading to WP-Stateless 3.2.0, please, make sure you use PHP 7.2 or abo
 Before upgrading to WP-Stateless 3.0, please, make sure you tested it on your development environment.
 
 == Changelog ==
+= 4.0.3 =
+* NEW - added `Info` section to the `Status` tab on the Settings page, which contains the system info and the ability to copy report to clipboard.  
+* ENHANCEMENT - added `Documentation` link on the Plugins page.
+* ENHANCEMENT - added `Addons` link on the Plugins page.
+* ENHANCEMENT - added `Documentation` link on the Settings page.
+* FIX - fixed `Settings` shortcut on the Plugins page.
+* FIX - in multisite network, do not show Data Optimization on the Network Admin Page.
+* FIX - properly set `Content Disposition` fields for media objects.
+* FIX - properly use `Cache Control` setting for media objects.
+* FIX - fixed `Creation of dynamic property` PHP deprecation notice.
+* FIX - fixed `Cannot use ::class with dynamic class name` PHP warning.
+* FIX - avoid PHP warning when unable to get file path in `Stateless` mode [728](https://github.com/udx/wp-stateless/issues/728).
+* FIX - fixed links to the constants documentation.
+
 = 4.0.2 =
 * FIX - in multisite network, deleting site can potentially remove WP-Stateless tables from another site.
 * COMPATIBILITY - Gravity Forms Compatibility updated for the newest Gravity Forms version.

--- a/static/scripts/wp-stateless-settings.js
+++ b/static/scripts/wp-stateless-settings.js
@@ -38,4 +38,22 @@ jQuery(document).ready(function ($) {
   $(document).on('click', '.wp-pointer', function (e) {
     e.stopPropagation()
   })
+
+  $(document).on('click', '.stateless-info-button', function (e) {
+    e.stopPropagation()
+    e.preventDefault()
+
+    var opened = $(this).closest('.stateless-info-heading').hasClass('open')
+    var id = $(this).data('section')
+    
+    if (opened) {
+      $(this).closest('.stateless-info-heading').removeClass('open')
+      $('#' + id).addClass('hidden')
+    } else {
+      $(this).closest('.stateless-info-heading').addClass('open')
+      $('#' + id).removeClass('hidden')
+    }
+  })
+
+  new ClipboardJS('.stateless-info-heading .copy-button');
 })

--- a/static/styles/wp-stateless-settings.css
+++ b/static/styles/wp-stateless-settings.css
@@ -10,9 +10,28 @@
   padding: 15px;
   border-left: 3px solid #f79191;
 }
+
 #stateless-settings-page-title {
   margin-bottom: 20px;
 }
+
+.stateless-settings-docs-link {
+  display: inline-block;
+  text-decoration: none;
+}
+
+.stateless-settings-docs-link:focus,
+.stateless-settings-docs-link:active {
+  outline: none;
+  box-shadow: none;
+  color: #2271b1;
+}
+
+.stateless-settings-docs-link .dashicons-editor-help:before {
+  font-size: 30px;
+  vertical-align: middle;
+}
+
 #service_account_json {
   height: 20em;
 }

--- a/static/styles/wp-stateless-status.css
+++ b/static/styles/wp-stateless-status.css
@@ -15,17 +15,87 @@
   padding-left: 20px;
 }
 
+#stless_status_tab .stateless-info-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+#stless_status_tab .stateless-info-heading .copy-button {
+  background-color: #fff;
+  font-weight: 400;
+}
+
 /* Info table */
-#stless_status_tab .stateless-info-table tr {
+#stateless-info {
+  border: 1px solid #c3c4c7;
+}
+
+.stateless-info-heading {
+  margin: 0;
+  font-size: 13px;
+  border-top: 1px solid #c3c4c7;
+}
+
+.stateless-info-heading:first-child {
+  border-top: none;
+}
+
+.stateless-info-button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: #fff;
+  border: 0;
+  color: #2c3338;
+  cursor: pointer;
+  padding: 13px 20px;
+  text-align: left;
+  width: 100%;
+  user-select: auto;
+}
+
+.stateless-info-button:hover,
+.stateless-info-button:active {
+  background-color: #f6f7f7;
+}
+
+.stateless-info-heading.open .dashicons {
+  transform: rotate(180deg);
+}
+
+.stateless-info-block {
+  padding: 13px 20px;
+}
+
+.stateless-info-block tr {
   display: table-row;
 }
 
-#stless_status_tab .stateless-info-table tr:after {
+.stateless-info-block tr:after {
   display: none;
 }
 
-#stless_status_tab .stateless-info-table td {
+.stateless-info-block td {
   width: 50%;
+}
+
+.stateless-info-table-extended-value {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.stateless-info-table-extended-value:last-child {
+  cursor: pointer;
+}
+
+.stateless-info-table-extended-value em {
+  display: none;
+}
+
+.stateless-info-table-extended-value .dashicons {
+  margin-right: 5px;
 }
 
 /* Migrations section (Data updates) */

--- a/static/views/settings-sections/file-url.php
+++ b/static/views/settings-sections/file-url.php
@@ -88,7 +88,7 @@
       <p class="description">
         <strong id="notice-hashify_file_name"></strong>
         <span id="notice-hashify_file_name-mode">
-          <?php _e(sprintf("<b>Required by Stateless Mode. Override with the <a href='%s' target='_blank'>WP_STATELESS_MEDIA_CACHE_BUSTING</a> constant.</b>", "https://stateless.udx.io/docs/constants/#wp_stateless_media_cache_busting"), ud_get_stateless_media()->domain); ?>
+          <?php _e(sprintf("<b>Required by Stateless Mode. Override with the <a href='%s' target='_blank'>WP_STATELESS_MEDIA_CACHE_BUSTING</a> constant.</b>", ud_get_stateless_media()->get_docs_page_url('docs/constants/#wpstatelessmediacachebusting')), ud_get_stateless_media()->domain); ?>
         </span>
 
         <?php _e('Prepends a random set of numbers and letters to the filename. This is useful for preventing caching issues when uploading files that have the same filename.', ud_get_stateless_media()->domain); ?>

--- a/static/views/settings-sections/google-cloud-storage.php
+++ b/static/views/settings-sections/google-cloud-storage.php
@@ -47,7 +47,7 @@
         
       <p>
         <label for="gcs_cache_control_text">
-          <input name="sm[cache_control]" type="text" id="gcs_cache_control_text" class="regular-text ltr" placeholder="public, max-age=36000, must-revalidate" value="<?php echo $sm->cache_control; ?>">
+          <input name="sm[cache_control]" type="text" id="gcs_cache_control_text" class="regular-text ltr" placeholder="<?php echo ud_get_stateless_media()->get_default_cache_control(); ?>" value="<?php echo $sm->cache_control; ?>">
         </label>
       </p>
 

--- a/static/views/settings_interface.php
+++ b/static/views/settings_interface.php
@@ -1,6 +1,10 @@
 <div class="wrap">
   <div id="stateless-settings-page-title">
-    <h1><?php _e('WP-Stateless', ud_get_stateless_media()->domain); ?></h1>
+    <h1>
+      <?php _e('WP-Stateless', ud_get_stateless_media()->domain); ?> 
+      <a href="<?php echo ud_get_stateless_media()->get_docs_page_url(); ?>" title="<?php _e('Documentation', ud_get_stateless_media()->domain); ?>" target="_blank" class="stateless-settings-docs-link"><span class="dashicons dashicons-editor-help"></span></a>
+    </h1>
+    
     <div class="description"><?php _e('Upload and serve your WordPress media files from Google Cloud Storage.', ud_get_stateless_media()->domain); ?></div>
   </div>
   <h2 class="nav-tab-wrapper">

--- a/static/views/status-sections/info.php
+++ b/static/views/status-sections/info.php
@@ -1,23 +1,45 @@
 
 <div class="metabox-holder">
   <div class="postbox">
-	  <h2 class="hndle"><?php _e('Info', ud_get_stateless_media()->domain); ?></h2>
+	  <h2 class="hndle stateless-info-heading">
+      <?php _e('Info', ud_get_stateless_media()->domain); ?> 
+      <button type="button" class="button copy-button" data-clipboard-text="<?php echo $copy_text; ?>"><?php _e('Copy Info to Clipboard', ud_get_stateless_media()->domain); ?></button></h2>
 
     <div class="inside">
       <div class="main">
 
-        <table class="widefat striped stateless-info-table" role="presentation">
-					<tbody>
-            <?php foreach ($rows as $row ) : ?>
-              <tr>
-                <td class="label"><?php echo $row->label; ?></td>
-                <td class="value"><?php echo $row->value; ?></td>
-              </tr>
-             <?php endforeach;?>
-          </tbody>
-				</table>
+        <div id="stateless-info">
 
-      </div>
-    </div>
+          <?php foreach( $sections as $key => $section ) : ?>
+
+            <h3 class="stateless-info-heading">
+              <button class="stateless-info-button" data-section="stateless-info-block-<?php echo $key; ?>" type="button">
+                <span class="title"><?php echo $section->title; ?></span>
+                <span class="dashicons dashicons-arrow-down-alt2"></span>
+              </button>
+            </h3>
+
+            <div id="stateless-info-block-<?php echo $key; ?>" class="stateless-info-block hidden"\>
+              <table class="widefat striped" role="presentation">
+                <tbody>
+
+                <?php foreach( $section->rows as $row ) : ?>
+                    <tr>
+                      <td><?php echo $row->label; ?></td>
+                      <td><?php echo $row->value; ?></td>
+                    </tr>
+                  <?php endforeach; ?>
+
+                </tbody>
+              </table>
+            </div>
+
+          <?php endforeach; ?>
+        
+        </div> <!-- id="stateless-info" -->
+
+      </div> <!-- class="main" -->
+    </div> <!-- class="inside" -->
+
   </div>
 </div>

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -69,6 +69,7 @@ return array(
     'wpCloud\\StatelessMedia\\Status' => $baseDir . '/lib/classes/class-status.php',
     'wpCloud\\StatelessMedia\\Status\\Info' => $baseDir . '/lib/classes/status/class-info.php',
     'wpCloud\\StatelessMedia\\Status\\Migrations' => $baseDir . '/lib/classes/status/class-migrations.php',
+    'wpCloud\\StatelessMedia\\Status\\StatelessInfo' => $baseDir . '/lib/classes/status/class-info-stateless.php',
     'wpCloud\\StatelessMedia\\StreamWrapper' => $baseDir . '/lib/classes/class-gs-stream-wrapper.php',
     'wpCloud\\StatelessMedia\\SyncNonMedia' => $baseDir . '/lib/classes/class-sync-non-media.php',
     'wpCloud\\StatelessMedia\\Sync\\BackgroundSync' => $baseDir . '/lib/classes/sync/class-background-sync.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -110,6 +110,7 @@ class ComposerStaticInitc59d002476a452800baaf79c430753cb
         'wpCloud\\StatelessMedia\\Status' => __DIR__ . '/../..' . '/lib/classes/class-status.php',
         'wpCloud\\StatelessMedia\\Status\\Info' => __DIR__ . '/../..' . '/lib/classes/status/class-info.php',
         'wpCloud\\StatelessMedia\\Status\\Migrations' => __DIR__ . '/../..' . '/lib/classes/status/class-migrations.php',
+        'wpCloud\\StatelessMedia\\Status\\StatelessInfo' => __DIR__ . '/../..' . '/lib/classes/status/class-info-stateless.php',
         'wpCloud\\StatelessMedia\\StreamWrapper' => __DIR__ . '/../..' . '/lib/classes/class-gs-stream-wrapper.php',
         'wpCloud\\StatelessMedia\\SyncNonMedia' => __DIR__ . '/../..' . '/lib/classes/class-sync-non-media.php',
         'wpCloud\\StatelessMedia\\Sync\\BackgroundSync' => __DIR__ . '/../..' . '/lib/classes/sync/class-background-sync.php',

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'wpcloud/wp-stateless',
         'pretty_version' => 'dev-latest',
         'version' => 'dev-latest',
-        'reference' => '15d050d833585ee8566b7bcdd24752cbd00bb5e7',
+        'reference' => 'eafeb6838583f3d2dad20da1b5493d1981d092b4',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -70,7 +70,7 @@
         'wpcloud/wp-stateless' => array(
             'pretty_version' => 'dev-latest',
             'version' => 'dev-latest',
-            'reference' => '15d050d833585ee8566b7bcdd24752cbd00bb5e7',
+            'reference' => 'eafeb6838583f3d2dad20da1b5493d1981d092b4',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/wp-stateless-media.php
+++ b/wp-stateless-media.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://stateless.udx.io/
  * Description: Upload and serve your WordPress media files from Google Cloud Storage.
  * Author: UDX
- * Version: 4.0.2
+ * Version: 4.0.3
  * Text Domain: stateless-media
  * Author URI: https://udx.io
  * License: GPLv2 or later


### PR DESCRIPTION
* NEW - added `Info` section to the `Status` tab on the Settings page, which contains the system info and the ability to copy report to clipboard.  
* ENHANCEMENT - added `Documentation` link on the Plugins page.
* ENHANCEMENT - added `Addons` link on the Plugins page.
* ENHANCEMENT - added `Documentation` link on the Settings page.
* FIX - fixed `Settings` shortcut on the Plugins page.
* FIX - in multisite network, do not show Data Optimization on the Network Admin Page.
* FIX - properly set `Content Disposition` fields for media objects.
* FIX - properly use `Cache Control` setting for media objects.
* FIX - fixed `Creation of dynamic property` PHP deprecation notice.
* FIX - fixed `Cannot use ::class with dynamic class name` PHP warning.
* FIX - avoid PHP warning when unable to get file path in `Stateless` mode [728](https://github.com/udx/wp-stateless/issues/728).
* FIX - fixed links to the constants documentation.
