### PR TITLE
Latest => v4.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,10 @@
 == Changelog ==
+= 4.0.4 =
+* ENHANCEMENT - display success message after copying Status Info.
+* FIX - `Settings` page does not open or slow when there is big amount of attachments.
+* FIX - in multisite network, removing custom tables properly when deleting site.
+* FIX - skip setting ACL in Stateless mode and during Sync for the buckets with Uniform access, support WP_STATELESS_SKIP_ACL_SET constant [#712](https://github.com/udx/wp-stateless/issues/712).
+
 = 4.0.3 =
 * NEW - added `Info` section to the `Status` tab on the Settings page, which contains the system info and the ability to copy report to clipboard.  
 * ENHANCEMENT - added `Documentation` link on the Plugins page.

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,9 @@
+#### 4.0.4
+* ENHANCEMENT - display success message after copying Status Info.
+* FIX - `Settings` page does not open or slow when there is big amount of attachments.
+* FIX - in multisite network, removing custom tables properly when deleting site.
+* FIX - skip setting ACL in Stateless mode and during Sync for the buckets with Uniform access, support WP_STATELESS_SKIP_ACL_SET constant [#712](https://github.com/udx/wp-stateless/issues/712).
+
 #### 4.0.3
 * NEW - added `Info` section to the `Status` tab on the Settings page, which contains the system info and the ability to copy report to clipboard.  
 * ENHANCEMENT - added `Documentation` link on the Plugins page.

--- a/lib/classes/class-db.php
+++ b/lib/classes/class-db.php
@@ -207,7 +207,7 @@ namespace wpCloud\StatelessMedia {
        * @param int $site_id
        */
       public function clear_db($site_id) {
-        switch_to_blog($id);
+        switch_to_blog($site_id);
 
         $tables = array(
           $this->wpdb->prefix . 'files',

--- a/lib/classes/class-sync-non-media.php
+++ b/lib/classes/class-sync-non-media.php
@@ -142,12 +142,16 @@ namespace wpCloud\StatelessMedia {
              * @return media object
              */
             try {
-              $media = $object->update(array('metadata' => $args['metadata']) +
-                array(
-                  'cacheControl' => apply_filters('sm:item:cacheControl', ud_get_stateless_media()->get_default_cache_control(), $absolutePath),
-                  'predefinedAcl' => 'publicRead',
-                  'contentDisposition' => apply_filters('sm:item:contentDisposition', null, $absolutePath)
-                ));
+              $mediaOptions = array(
+                'cacheControl' => apply_filters('sm:item:cacheControl', ud_get_stateless_media()->get_default_cache_control(), $absolutePath),
+                'contentDisposition' => apply_filters('sm:item:contentDisposition', null, $absolutePath)
+              );
+
+              if ( !defined('WP_STATELESS_SKIP_ACL_SET') || !WP_STATELESS_SKIP_ACL_SET) {
+                $mediaOptions['predefinedAcl'] = 'publicRead';
+              }
+
+              $media = $object->update(array('metadata' => $args['metadata']) + $mediaOptions);
             } catch (\Throwable $th) {
               //throw $th;
             }

--- a/lib/classes/class-utility.php
+++ b/lib/classes/class-utility.php
@@ -326,12 +326,16 @@ namespace wpCloud\StatelessMedia {
                  * @return media object
                  */
                 try {
-                  $media = $object->update(array('metadata' => $media_args['metadata']) +
-                    array(
-                      'cacheControl' => $_cacheControl,
-                      'predefinedAcl' => 'publicRead',
-                      'contentDisposition' => $_contentDisposition
-                    ));
+                  $mediaOptions = array(
+                    'cacheControl' => $_cacheControl,
+                    'contentDisposition' => $_contentDisposition
+                  );
+
+                  if ( !defined('WP_STATELESS_SKIP_ACL_SET') || !WP_STATELESS_SKIP_ACL_SET) {
+                    $mediaOptions['predefinedAcl'] = 'publicRead';
+                  }
+      
+                  $media = $object->update(array('metadata' => $media_args['metadata']) + $mediaOptions);
 
                   $cloud_meta = self::generate_cloud_meta($cloud_meta, $media, $size, $img, $bucketLink);
                 } catch (\Throwable $th) {

--- a/lib/classes/status/class-info-stateless.php
+++ b/lib/classes/status/class-info-stateless.php
@@ -2,7 +2,7 @@
 /**
  * System Info (Stateless section) class
  *
- * @since 4.1.0
+ * @since 4.0.3
  */
 
 namespace wpCloud\StatelessMedia\Status;

--- a/lib/classes/status/class-info.php
+++ b/lib/classes/status/class-info.php
@@ -2,7 +2,7 @@
 /**
  * System Info class
  *
- * @since 4.1.0
+ * @since 4.0.3
  */
 
 namespace wpCloud\StatelessMedia\Status;
@@ -185,14 +185,9 @@ class Info {
       return $values;
     }
 
-    $query = new \WP_Query([
-      'post_type' => 'attachment',
-      'post_status' => 'any',
-      'posts_per_page' => -1,
-    ]);
-
-    $total = $query->found_posts;
-
+    global $wpdb;
+    $total = $wpdb->get_var("SELECT COUNT(*) FROM $wpdb->posts WHERE post_type = 'attachment'");
+    
     $sizes = get_intermediate_image_sizes();
 
     $rows = [

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Tags: google cloud, google cloud storage, cdn, uploads, backup
 License: GPLv2 or later
 Requires PHP: 8.0
 Requires at least: 5.0
-Tested up to: 6.5.2
-Stable tag: 4.0.3
+Tested up to: 6.5.4
+Stable tag: 4.0.4
 
 Upload and serve your WordPress media files from Google Cloud Storage.
 
@@ -121,6 +121,12 @@ Before upgrading to WP-Stateless 3.2.0, please, make sure you use PHP 7.2 or abo
 Before upgrading to WP-Stateless 3.0, please, make sure you tested it on your development environment.
 
 == Changelog ==
+= 4.0.4 =
+* ENHANCEMENT - display success message after copying Status Info.
+* FIX - `Settings` page does not open or slow when there is big amount of attachments.
+* FIX - in multisite network, removing custom tables properly when deleting site.
+* FIX - skip setting ACL in Stateless mode and during Sync for the buckets with Uniform access, support WP_STATELESS_SKIP_ACL_SET constant [#712](https://github.com/udx/wp-stateless/issues/712).
+
 = 4.0.3 =
 * NEW - added `Info` section to the `Status` tab on the Settings page, which contains the system info and the ability to copy report to clipboard.  
 * ENHANCEMENT - added `Documentation` link on the Plugins page.

--- a/static/scripts/wp-stateless-settings.js
+++ b/static/scripts/wp-stateless-settings.js
@@ -55,5 +55,13 @@ jQuery(document).ready(function ($) {
     }
   })
 
-  new ClipboardJS('.stateless-info-heading .copy-button');
+  var clipboard = new ClipboardJS('.stateless-info-heading .copy-button')
+
+  clipboard.on('success', function(e) {
+    $('.stateless-info-copy-success').show();
+
+    setTimeout(function() {
+      $('.stateless-info-copy-success').fadeOut(500);
+    }, 5000);
+  })
 })

--- a/static/styles/wp-stateless-status.css
+++ b/static/styles/wp-stateless-status.css
@@ -26,6 +26,14 @@
   font-weight: 400;
 }
 
+.stateless-info-copy-success {
+  line-height: 30px;
+  margin-right: 5px;
+  color: #007017;
+  font-weight: normal;
+  display: none;
+}
+
 /* Info table */
 #stateless-info {
   border: 1px solid #c3c4c7;

--- a/static/views/status-sections/info.php
+++ b/static/views/status-sections/info.php
@@ -2,8 +2,12 @@
 <div class="metabox-holder">
   <div class="postbox">
 	  <h2 class="hndle stateless-info-heading">
-      <?php _e('Info', ud_get_stateless_media()->domain); ?> 
-      <button type="button" class="button copy-button" data-clipboard-text="<?php echo $copy_text; ?>"><?php _e('Copy Info to Clipboard', ud_get_stateless_media()->domain); ?></button></h2>
+      <?php _e('Info', ud_get_stateless_media()->domain); ?>
+      <div>
+        <span class="stateless-info-copy-success"><?php _e('Copied!', ud_get_stateless_media()->domain); ?></span>
+        <button type="button" class="button copy-button" data-clipboard-text="<?php echo $copy_text; ?>"><?php _e('Copy Info to Clipboard', ud_get_stateless_media()->domain); ?></button>
+      </div>
+    </h2>
 
     <div class="inside">
       <div class="main">

--- a/wp-stateless-media.php
+++ b/wp-stateless-media.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://stateless.udx.io/
  * Description: Upload and serve your WordPress media files from Google Cloud Storage.
  * Author: UDX
- * Version: 4.0.3
+ * Version: 4.0.4
  * Text Domain: stateless-media
  * Author URI: https://udx.io
  * License: GPLv2 or later


### PR DESCRIPTION
* ENHANCEMENT - display success message after copying Status Info.
* FIX - `Settings` page does not open or slow when there is big amount of attachments.
* FIX - in multisite network, removing custom tables properly when deleting site.
* FIX - skip setting ACL in Stateless mode and during Sync for the buckets with Uniform access, support WP_STATELESS_SKIP_ACL_SET constant [#712](https://github.com/udx/wp-stateless/issues/712).
