### PR TITLE
Add link to Youtube video installation & setup guide

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ Looking for a unique feature for your next project? [Hire us!](https://udx.io/)
 4. Set a Google Cloud Project, Google Cloud Storage Bucket, and Google Cloud Billing Account and click "Continue."
 5. Installation and setup are now complete. Visit *Media > Stateless Settings* for more options.
 
-For a more detailed installation and setup walkthrough, please see the [manual setup instructions on Github](https://stateless.udx.io/docs/manual-setup/).
+For a more detailed , please see the [manual setup instructions on Github](https://stateless.udx.io/docs/manual-setup/). Or refer to ["wp-cloud-run" Youtube video](https://www.youtube.com/watch?v=wStYyOWlJCU&list=PL83G0TLSeXREwjHDZPsV_34azAmniL81V) for video guide and instructions on how to do the same.
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
Added a link in Readme that point to video how to [Setup WP Stateless plugin to store WordPress media on GCS Google Cloud Storage bucket](https://www.youtube.com/watch?v=wStYyOWlJCU&list=PL83G0TLSeXREwjHDZPsV_34azAmniL81V) which is part of a [wp-cloud-run: Ultimate WordPress setup on (GCP) Cloud Run"](https://www.youtube.com/playlist?list=PL83G0TLSeXREwjHDZPsV_34azAmniL81V)  Youtube playlist. 

For more reference see the blog post: https://foolcontrol.org/?p=4802